### PR TITLE
edit startup scripts to unset license variables

### DIFF
--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -17,5 +17,8 @@ elif test -f "/etc/rstudio-connect/license.lic"; then
     /opt/rstudio-connect/bin/license-manager activate-file /etc/rstudio-connect/license.lic
 fi
 
+# lest this be inherited by child processes
+unset RSC_LICENSE
+
 # Start RStudio Connect
 /opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg

--- a/package-manager/startup.sh
+++ b/package-manager/startup.sh
@@ -17,5 +17,8 @@ elif test -f "/etc/rstudio-pm/license.lic"; then
     /opt/rstudio-pm/bin/license-manager activate-file /etc/rstudio-pm/license.lic
 fi
 
+# lest this be inherited by child processes
+unset RSPM_LICENSE
+
 # Start RStudio Package Manager
 /opt/rstudio-pm/bin/rstudio-pm --config /etc/rstudio-pm/rstudio-pm.gcfg

--- a/server-pro/startup.sh
+++ b/server-pro/startup.sh
@@ -17,6 +17,9 @@ elif test -f "/etc/rstudio-server/license.lic"; then
     rstudio-server license-manager activate-file /etc/rstudio-server/license.lic
 fi
 
+# lest this be inherited by child processes
+unset RSP_LICENSE
+
 # Create one user
 if [ $(getent passwd $RSP_TESTUSER_UID) ] ; then
     echo "UID $RSP_TESTUSER_UID already exists, not creating $RSP_TESTUSER test user";


### PR DESCRIPTION
Close #2 

The risk here is that otherwise the *_LICENSE will be exposed to all child processes (R processes, Shiny apps, etc.)