### PR TITLE
Add daily

### DIFF
--- a/server-pro/.env
+++ b/server-pro/.env
@@ -1,1 +1,2 @@
 RSP_VERSION=1.2.5019-6
+RSP_DOWNLOAD_URL=https://download2.rstudio.org/server/trusty/amd64

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -34,7 +34,8 @@ RUN /opt/python/${PYTHON_VERSION}/bin/pip install jupyter jupyterlab rsp_jupyter
 
 # Install RStudio Server Pro --------------------------------------------------#
 ARG RSP_VERSION=1.2.5019-6
-RUN curl -O https://download2.rstudio.org/server/trusty/amd64/rstudio-server-pro-${RSP_VERSION}-amd64.deb && \
+ARG RSP_DOWNLOAD_URL=https://download2.rstudio.org/server/trusty/amd64
+RUN curl -O ${RSP_DOWNLOAD_URL}/rstudio-server-pro-${RSP_VERSION}-amd64.deb && \
     gdebi --non-interactive rstudio-server-pro-${RSP_VERSION}-amd64.deb && \
     rm rstudio-server-pro-${RSP_VERSION}-amd64.deb
 

--- a/server-pro/hooks/build
+++ b/server-pro/hooks/build
@@ -4,4 +4,4 @@
 # https://stackoverflow.com/questions/19331497/set-environment-variables-from-file-of-key-value-pairs
 export $(grep -v '^#' .env | xargs)
 
-docker build --build-arg RSP_VERSION=${RSP_VERSION} -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+docker build --build-arg RSP_VERSION=${RSP_VERSION} --build-arg RSP_DOWNLOAD_URL=${RSP_DOWNLOAD_URL} -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/server-pro/hooks/post_push
+++ b/server-pro/hooks/post_push
@@ -10,6 +10,11 @@ imageStart=$(expr index "$IMAGE_NAME" /)
 repoName=${IMAGE_NAME:0:tagStart-1}
 imageName=${IMAGE_NAME:imageStart:${#IMAGE_NAME}-tagStart-1}
 
+if [ "${DOCKER_TAG}" == "daily" ]; then
+  echo "Daily build - exiting and not tagging version number"
+  exit 0
+fi
+
 # use xargs -0 (BSD) or xargs -d '\n' (GNU) to read env vars with spaces
 # https://stackoverflow.com/questions/19331497/set-environment-variables-from-file-of-key-value-pairs
 export $(grep -v '^#' .env | xargs)

--- a/server-pro/hooks/pre_build
+++ b/server-pro/hooks/pre_build
@@ -5,7 +5,7 @@
 if [ "${DOCKER_TAG}" == "daily" ]; then
   # get daily version
   rawpage=`curl -s https://dailies.rstudio.com/rstudioserver/pro/bionic/x86_64/`
-  if [[ "$rawpage" =~ rstudio-server-pro-([0-9.\-]*)-amd64.deb ]]; then
+  if [[ "$rawpage" =~ rstudio-server-pro-([0-9\.\-]*)-amd64.deb ]]; then
     match="${BASH_REMATCH[1]}"
     echo "Latest version found: $match"
     sed -i '' "s/^RSP_VERSION=.*/RSP_VERSION=${match}/g" ./.env

--- a/server-pro/hooks/pre_build
+++ b/server-pro/hooks/pre_build
@@ -5,6 +5,8 @@
 if [ "${DOCKER_TAG}" == "daily" ]; then
   # get daily version
   rawpage=`curl -s https://dailies.rstudio.com/rstudioserver/pro/bionic/x86_64/`
+
+  # thanks to https://stackoverflow.com/a/44490624/6570011
   if [[ "$rawpage" =~ rstudio-server-pro-([0-9\.\-]*)-amd64.deb ]]; then
     match="${BASH_REMATCH[1]}"
     echo "Latest version found: $match"

--- a/server-pro/hooks/pre_build
+++ b/server-pro/hooks/pre_build
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# if daily build
+# replace version number and download url
+if [ "${DOCKER_TAG}" == "daily" ]; then
+  # get daily version
+  rawpage=`curl -s https://dailies.rstudio.com/rstudioserver/pro/bionic/x86_64/`
+  if [[ "$rawpage" =~ rstudio-server-pro-([0-9.\-]*)-amd64.deb ]]; then
+    match="${BASH_REMATCH[1]}"
+    echo "Latest version found: $match"
+    sed -i '' "s/^RSP_VERSION=.*/RSP_VERSION=${match}/g" ./.env
+    sed -i '' "s|^RSP_DOWNLOAD_URL=.*|RSP_DOWNLOAD_URL=https://dailies.rstudio.com/rstudioserver/pro/bionic/x86_64|g" ./.env
+  fi
+fi

--- a/server-pro/hooks/pre_build
+++ b/server-pro/hooks/pre_build
@@ -10,5 +10,9 @@ if [ "${DOCKER_TAG}" == "daily" ]; then
     echo "Latest version found: $match"
     sed -i '' "s/^RSP_VERSION=.*/RSP_VERSION=${match}/g" ./.env
     sed -i '' "s|^RSP_DOWNLOAD_URL=.*|RSP_DOWNLOAD_URL=https://dailies.rstudio.com/rstudioserver/pro/bionic/x86_64|g" ./.env
+  else
+    # fail the build
+    echo "ERROR parsing latest daily version"
+    exit 1
   fi
 fi


### PR DESCRIPTION
Hoping for a better approach to getting the "daily" version after feedback from the IDE team. At present, just parsing the `dailies` download data for a version number. Essentially:

- make `RSP_DOWNLOAD_URL` configurable
- add a `pre_build` hook that replaces the `RSP_VERSION` and `RSP_DOWNLOAD_URL` for the `daily` tag. Grabs the latest version from the first `.deb` on the RSP/Ubuntu download page.
- make the `post_push` hook _not_ fire for the `daily` tag (alternatively, we could _only_ fire that hook for the `latest` tag... not sure which is preferable... Right now we only have the two builds, so they are equivalent)

If / once merged, we will add a `daily` build that makes use of these hooks in docker hub

Close #10 