### PR TITLE
Set Git.BuilderDir

### DIFF
--- a/package-manager/rstudio-pm.gcfg
+++ b/package-manager/rstudio-pm.gcfg
@@ -6,3 +6,6 @@ DataDir = /data
 
 [Server]
 RVersion = /opt/R/3.6.2/
+
+[Git]
+BuilderDir = "/tmp/git"


### PR DESCRIPTION
When mounting the `DataDir` from mac starting `ssh-agent` from RSPM failed with:

```
bind: File name too long
unix_listener: cannot bind to path: /data/git/rspm_ssh_agent.2883ab5b8509.sock
```

The short story is that the the path is indeed too long for `bind` even if it looks short in the docker filesystem because of some mount things in Mac. Long story: https://github.com/moby/moby/issues/23545#issuecomment-226144475

This comes from this ticket (https://rstudioide.zendesk.com/agent/tickets/43311) in k8s is probably happening the same thing.

The simple solution was to change the Git.BuildDir to be ephemeral, i dont think this will cause any issues.