### PR TITLE
Make Rsp more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ See the [RStudio Server Pro guide](https://docs.rstudio.com/ide/server-pro/authe
 | `RSP_TESTUSER_PASSWD` | Test user password | `rstudio` |
 | `RSP_TESTUSER_UID` | Test user UID | `10000` |
 | `RSP_LICENSE` | License key for RStudio Server Pro, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX` | None |
+| `LAUNCHER_TIMEOUT` | The timeout, in seconds, to wait for launcher to startup before proceeding | 10 |
 
 #### Ports
 

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -36,6 +36,7 @@ RUN /opt/python/${PYTHON_VERSION}/bin/pip install jupyter jupyterlab rsp_jupyter
 ARG RSP_VERSION=1.2.5033-1
 ARG RSP_DOWNLOAD_URL=https://download2.rstudio.org/server/trusty/amd64
 RUN curl -O ${RSP_DOWNLOAD_URL}/rstudio-server-pro-${RSP_VERSION}-amd64.deb && \
+    apt-get update --fix-missing && \
     gdebi --non-interactive rstudio-server-pro-${RSP_VERSION}-amd64.deb && \
     rm rstudio-server-pro-${RSP_VERSION}-amd64.deb
 

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -61,6 +61,7 @@ COPY conf/launcher.conf /etc/rstudio/launcher.conf
 COPY conf/jupyter.conf /etc/rstudio/jupyter.conf
 COPY conf/repos.conf /etc/rstudio/repos.conf
 COPY conf/launcher-env /etc/rstudio/launcher-env
+COPY conf/logging.conf /etc/rstudio/logging.conf
 VOLUME ["/etc/rstudio-server/license.lic"]
 
 COPY startup.sh /usr/local/bin/startup.sh

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -54,6 +54,7 @@ ENV RSP_LICENSE ""
 ENV RSP_TESTUSER rstudio
 ENV RSP_TESTUSER_PASSWD rstudio
 ENV RSP_TESTUSER_UID 10000
+ENV LAUNCHER_TIMEOUT 10
 
 COPY conf/rserver.conf /etc/rstudio/rserver.conf
 COPY conf/launcher.conf /etc/rstudio/launcher.conf

--- a/server-pro/conf/logging.conf
+++ b/server-pro/conf/logging.conf
@@ -1,0 +1,3 @@
+[*]
+log-level=info
+logger-type=stderr

--- a/server-pro/startup.sh
+++ b/server-pro/startup.sh
@@ -34,14 +34,15 @@ fi
 
 
 # Start Server Pro
-/usr/lib/rstudio-server/bin/rstudio-launcher &
+/usr/lib/rstudio-server/bin/rstudio-launcher > /var/log/rstudio-launcher.log 2>&1 &
 wait-for-it.sh localhost:5559 -t $LAUNCHER_TIMEOUT
 
 # touch log files to initialize them
 su rstudio-server -c 'touch /var/lib/rstudio-server/monitor/log/rstudio-server.log'
+touch /var/log/rstudio-server.log
 
-tail -f /var/lib/rstudio-server/monitor/log/*.log /var/lib/rstudio-launcher/*.log /var/lib/rstudio-launcher/Local/*.log &
+tail -n 100 -f /var/lib/rstudio-server/monitor/log/*.log /var/lib/rstudio-launcher/*.log /var/lib/rstudio-launcher/Local/*.log /var/log/rstudio-launcher.log /var/log/rstudio-server.log &
 
 # the main container process
 # cannot use "exec" or the "trap" will be lost
-/usr/lib/rstudio-server/bin/rserver --server-daemonize 0
+/usr/lib/rstudio-server/bin/rserver --server-daemonize 0 > /var/log/rstudio-server.log 2>&1

--- a/server-pro/startup.sh
+++ b/server-pro/startup.sh
@@ -34,8 +34,14 @@ fi
 
 
 # Start Server Pro
-/usr/lib/rstudio-server/bin/rstudio-launcher > /dev/null 2>&1 &
-wait-for-it.sh localhost:5559 -t 0
-/usr/lib/rstudio-server/bin/rserver
-wait-for-it.sh localhost:8787 -t 0
-tail -f /var/lib/rstudio-server/monitor/log/*.log /var/lib/rstudio-launcher/*.log /var/lib/rstudio-launcher/Local/*.log
+/usr/lib/rstudio-server/bin/rstudio-launcher &
+wait-for-it.sh localhost:5559 -t $LAUNCHER_TIMEOUT
+
+# touch log files to initialize them
+su rstudio-server -c 'touch /var/lib/rstudio-server/monitor/log/rstudio-server.log'
+
+tail -f /var/lib/rstudio-server/monitor/log/*.log /var/lib/rstudio-launcher/*.log /var/lib/rstudio-launcher/Local/*.log &
+
+# the main container process
+# cannot use "exec" or the "trap" will be lost
+/usr/lib/rstudio-server/bin/rserver --server-daemonize 0


### PR DESCRIPTION
- Switch how the Launcher and the rserver process log (to a file instead of to `/dev/null`)
- Add those files to the `tail -f` command
- Add `-n 100` to the tail command so it picks up the first 100 lines (instead of first 10)
- Switch command order so that the `rserver` process is the main container process
- Add `LAUNCHER_TIMEOUT` variable that configures how long we wait for the launcher

Confirmed that if the `rserver` process dies, that the container dies.