### PR TITLE
remove directory volumes

### DIFF
--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -41,7 +41,7 @@ RUN chmod +x /usr/local/bin/startup.sh
 EXPOSE 3939/tcp
 ENV RSC_LICENSE ""
 COPY rstudio-connect.gcfg /etc/rstudio-connect/rstudio-connect.gcfg
-VOLUME ["/data", "/etc/rstudio-connect/license.lic"]
+VOLUME ["/data"]
 
 ENTRYPOINT ["tini", "--"]
 CMD ["/usr/local/bin/startup.sh"]

--- a/package-manager/Dockerfile
+++ b/package-manager/Dockerfile
@@ -30,7 +30,7 @@ RUN chmod +x /usr/local/bin/startup.sh
 EXPOSE 4242/tcp
 ENV RSPM_LICENSE ""
 COPY rstudio-pm.gcfg /etc/rstudio-pm/rstudio-pm.gcfg
-VOLUME ["/data", "/etc/rstudio-pm/license.lic"]
+VOLUME ["/data"]
 
 ENTRYPOINT ["tini", "--"]
 CMD ["/usr/local/bin/startup.sh"]

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -62,7 +62,6 @@ COPY conf/jupyter.conf /etc/rstudio/jupyter.conf
 COPY conf/repos.conf /etc/rstudio/repos.conf
 COPY conf/launcher-env /etc/rstudio/launcher-env
 COPY conf/logging.conf /etc/rstudio/logging.conf
-VOLUME ["/etc/rstudio-server/license.lic"]
 
 COPY startup.sh /usr/local/bin/startup.sh
 RUN chmod +x /usr/local/bin/startup.sh

--- a/server-pro/startup.sh
+++ b/server-pro/startup.sh
@@ -38,7 +38,8 @@ fi
 wait-for-it.sh localhost:5559 -t $LAUNCHER_TIMEOUT
 
 # touch log files to initialize them
-su rstudio-server -c 'touch /var/lib/rstudio-server/monitor/log/rstudio-server.log'
+touch /var/lib/rstudio-server/monitor/log/rstudio-server.log
+chown rstudio-server:rstudio-server /var/lib/rstudio-server/monitor/log/rstudio-server.log
 touch /var/log/rstudio-server.log
 
 tail -n 100 -f /var/lib/rstudio-server/monitor/log/*.log /var/lib/rstudio-launcher/*.log /var/lib/rstudio-launcher/Local/*.log /var/log/rstudio-launcher.log /var/log/rstudio-server.log &


### PR DESCRIPTION
remove directory volumes
fix touch issue that breaks rsp image

`VOLUME` apparently creates a directory, which you cannot mount over with a file

I will follow up later to figure out why our testing didn't catch this