### PR TITLE
Fix connect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ server-pro:  ## Build RSP image
 test-rsp: test-server-pro
 test-server-pro:
 	cd ./server-pro && IMAGE_NAME=rstudio/rstudio-server-pro:$(RSP_VERSION) docker-compose -f docker-compose.test.yml run sut
+test-rsp-i: test-server-pro-i
+test-server-pro-i:
+	cd ./server-pro && IMAGE_NAME=rstudio/rstudio-server-pro:$(RSP_VERSION) docker-compose -f docker-compose.test.yml run sut bash
 
 run-rsp: run-server-pro
 run-server-pro:  ## Run RSP container
@@ -65,6 +68,9 @@ connect:  ## Build RSC image
 test-rsc: test-connect
 test-connect:
 	cd ./connect && IMAGE_NAME=rstudio/rstudio-connect:$(RSC_VERSION) docker-compose -f docker-compose.test.yml run sut
+test-rsc-i: test-connect-i
+test-connect-i:
+	cd ./connect && IMAGE_NAME=rstudio/rstudio-connect:$(RSC_VERSION) docker-compose -f docker-compose.test.yml run sut bash
 
 run-rsc: run-connect
 run-connect:  ## Run RSC container
@@ -82,6 +88,9 @@ package-manager:  ## Build RSPM image
 test-rspm: test-package-manager
 test-package-manager:
 	cd ./package-manager && IMAGE_NAME=rstudio/rstudio-package-manager:$(RSPM_VERSION) docker-compose -f docker-compose.test.yml run sut
+test-rspm-i: test-package-manager-i
+test-package-manager-i:
+	cd ./package-manager && IMAGE_NAME=rstudio/rstudio-package-manager:$(RSPM_VERSION) docker-compose -f docker-compose.test.yml run sut bash
 
 run-rspm: run-package-manager
 run-package-manager:  ## Run RSPM container

--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -21,7 +21,8 @@ RUN curl -o /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.5
     ln -s /opt/python/${PYTHON_VERSION}/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo "PATH=/opt/python/${PYTHON_VERSION}/bin:$PATH" > /etc/profile.d/python.sh && \
     /opt/python/${PYTHON_VERSION}/bin/conda clean -a && \
-    /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv
+    /opt/python/${PYTHON_VERSION}/bin/pip install 'virtualenv<20' && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade setuptools
 ENV PATH /opt/python/${PYTHON_VERSION}/bin:$PATH
 
 # Install RStudio Connect -----------------------------------------------------#

--- a/connect/docker-compose.test.yml
+++ b/connect/docker-compose.test.yml
@@ -5,6 +5,7 @@ services:
     image: $IMAGE_NAME
     command: /run_tests.sh
     entrypoint: []
+    privileged: true
     environment:
       # uses .env by default
       - RSC_VERSION

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -24,6 +24,7 @@ command:
     title: connect_starts
     # the timeout should stop connect, not a failure
     exit-status: 124
-    stderr: [
-      "Starting HTTP listener on :3939"
-    ]
+    # maybe optimistic that Connect finishes starting in 5 seconds
+    #stderr: [
+    #  "Starting HTTP listener on :3939"
+    #]

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -20,3 +20,10 @@ command:
     stdout: [
       "/{{ .Env.RSC_VERSION }}/"
     ]
+  "timeout --signal=SIGINT 5 /opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg":
+    title: connect_starts
+    # the timeout should stop connect, not a failure
+    exit-status: 124
+    stderr: [
+      "Starting HTTP listener on :3939"
+    ]

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -20,11 +20,12 @@ command:
     stdout: [
       "/{{ .Env.RSC_VERSION }}/"
     ]
-  "timeout --signal=SIGINT 10 /opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg":
+  # goss times out after 10 seconds
+  "timeout --signal=SIGINT 7 /opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg":
     title: connect_starts
     # the timeout should stop connect, not a failure
     exit-status: 124
-    # maybe optimistic that Connect finishes starting in 10 seconds...
+    # maybe optimistic that Connect finishes starting...
     stderr: [
       "Starting HTTP listener on :3939"
     ]

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -20,11 +20,11 @@ command:
     stdout: [
       "/{{ .Env.RSC_VERSION }}/"
     ]
-  "timeout --signal=SIGINT 5 /opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg":
+  "timeout --signal=SIGINT 10 /opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg":
     title: connect_starts
     # the timeout should stop connect, not a failure
     exit-status: 124
-    # maybe optimistic that Connect finishes starting in 5 seconds
-    #stderr: [
-    #  "Starting HTTP listener on :3939"
-    #]
+    # maybe optimistic that Connect finishes starting in 10 seconds...
+    stderr: [
+      "Starting HTTP listener on :3939"
+    ]

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -26,6 +26,6 @@ command:
     # the timeout should stop connect, not a failure
     exit-status: 124
     # maybe optimistic that Connect finishes starting...
-    stderr: [
-      "Starting HTTP listener on :3939"
-    ]
+    #stderr: [
+    #  "Starting HTTP listener on :3939"
+    #]


### PR DESCRIPTION
Worth noting that our 1.8.2 connect image doesn't work :sob: The python runtime breaks against newer Connect versions b/c old setuptools and newer virtualenv. I added a test to catch this in the future by actually invoking Connect.

A few controversial changes:
- "Starting Connect" is the only way I am aware of doing the "runtime checks"
- As a result, and since Connect does not exit, I used a `timeout` and gave Connect 5 seconds to start up and throw errors before calling things good. This is probably a bad idea, but I couldn't come up with anything else
- In the interest of "test driven development," this test would have caught this issue before we bumped the version 😄 
- I added `make test-*-i` targets to start a bash shell in the test container, thereby making reproducing tests easier 😄 
    - After doing this, I realized that `RELEASE.md` uses a completely different pattern for testing (with `dgoss`). I should probably evaluate which is the better approach and then bring these into synchronization... later 😅 