### PR TITLE
add metrics configuration for monitoring

### DIFF
--- a/package-manager/Dockerfile
+++ b/package-manager/Dockerfile
@@ -28,6 +28,7 @@ COPY startup.sh /usr/local/bin/startup.sh
 RUN chmod +x /usr/local/bin/startup.sh
 
 EXPOSE 4242/tcp
+EXPOSE 2112/tcp
 ENV RSPM_LICENSE ""
 ENV RSPM_LICENSE_SERVER ""
 COPY rstudio-pm.gcfg /etc/rstudio-pm/rstudio-pm.gcfg

--- a/package-manager/rstudio-pm.gcfg
+++ b/package-manager/rstudio-pm.gcfg
@@ -9,3 +9,6 @@ RVersion = /opt/R/3.6.2/
 
 [Git]
 BuilderDir = "/tmp/git"
+
+[Metrics]
+Enabled = true


### PR DESCRIPTION
thought this would be a helpful addition to the default image for RSPM
exposes a prometheus endpoint for monitoring