### PR TITLE
Fix float

### DIFF
--- a/helper/float/Dockerfile
+++ b/helper/float/Dockerfile
@@ -45,7 +45,8 @@ RUN echo '\n\
     <!-- <proxy url="http://user:pass@127.0.0.1:8080/"/> -->\n\
 </config>\n\
 \n'\
-| sed -s "s/{{PORT}}/${PORT}/" > /etc/${PRODUCT}-license-server.conf 
+| sed -s "s/{{PORT}}/${PORT}/" > /etc/${PRODUCT}-license-server.conf && \
+sed -i "s/\${PRODUCT}/${PRODUCT}/" /usr/local/bin/startup.sh
 
 ENTRYPOINT [ "tini", "--" ]
 CMD [ "/usr/local/bin/startup.sh" ]

--- a/helper/float/startup.sh
+++ b/helper/float/startup.sh
@@ -42,6 +42,7 @@ activate
 trap deactivate EXIT
 
 echo "Starting server ..."
+# background so that stdout / stderr continue going to the parent shell
 /usr/lib/${PRODUCT}-license-server/bin/license-server \
 	-pdets=/usr/lib/${PRODUCT}-license-server/bin/license-server.dat \
 	-config=/etc/${PRODUCT}-license-server.conf \

--- a/helper/float/startup.sh
+++ b/helper/float/startup.sh
@@ -25,8 +25,7 @@ activate() {
 deactivate() {
     echo "Stopping server"
     PID=$(cat /var/run/${PRODUCT}-license-server.pid)
-    # TODO: kill -9 ?
-    kill $PID
+    kill -9 $PID
     wait $PID
     echo "Deactivating license ..."
     /usr/lib/${PRODUCT}-license-server/bin/license-server \

--- a/helper/float/startup.sh
+++ b/helper/float/startup.sh
@@ -4,11 +4,9 @@ if [ -z "$LICENSE" ]; then
     "$@"
     exit 1
 fi
-if [ -z "$PRODUCT" ]; then
-    echo >&2 'error: The PRODUCT variable is not set. Should be one of rsp, connect, rspm, ssp, rstudio'
-    "$@"
-    exit 1
-fi
+
+# NOTE: the PRODUCT is replaced / substituted at build time by sed
+# (i.e. verbatim text replacement)
 
 activate() {
     echo "Activating LICENSE ..."

--- a/helper/float/startup.sh
+++ b/helper/float/startup.sh
@@ -25,8 +25,17 @@ activate() {
 }
 
 deactivate() {
+    echo "Stopping server"
+    PID=$(cat /var/run/${PRODUCT}-license-server.pid)
+    # TODO: kill -9 ?
+    kill $PID
+    wait $PID
     echo "Deactivating license ..."
-    /usr/lib/${PRODUCT}-license-server/bin/license-server -deact >/dev/null 2>&1
+    /usr/lib/${PRODUCT}-license-server/bin/license-server \
+	-pdets=/usr/lib/${PRODUCT}-license-server/bin/license-server.dat \
+	-config=/etc/${PRODUCT}-license-server.conf \
+	-deact
+    echo "Done"
 }
 
 activate
@@ -39,7 +48,11 @@ echo "Starting server ..."
 	-pdets=/usr/lib/${PRODUCT}-license-server/bin/license-server.dat \
 	-config=/etc/${PRODUCT}-license-server.conf \
 	-pidfile=/var/run/${PRODUCT}-license-server.pid \
-	-x
+	-x &
+
+SERVER_PID=$!
+echo "Waiting for PID: $SERVER_PID"
+wait $SERVER_PID
 
 #"$@"
 #STATUS="$?"


### PR DESCRIPTION
I found out why the floating container constantly needs to be reset!

- The server process has to be dead in order to deactivate the license 😑 
- We tether the container to the server process so that that can't happen

I fixed by:
- Making _sure_ that the process is dead before deactivating
- Using the `wait` command to leave the bash shell as the parent process and tether to the server process while allowing me to kill the server process if I need to (i.e. in order to deactivate)

It seems to work pretty well in testing!! Not sure how the following would be handled:
- networking blips / not able to contact the deactivation server
- if the process doesn't respond to `kill` in some context... Maybe we should `kill -9`?

This should at least make testing with the floating license server less painful.

Also, we had `PRODUCT` as an arg, but also as a required runtime env var. Yuck. Sorry about that - I fixed with `sed` substitution