### PR TITLE
Fix openssl

### DIFF
--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -32,7 +32,6 @@ RUN curl -o /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.5
     /opt/python/${PYTHON_VERSION}/bin/conda clean -tipsy && \
     /opt/python/${PYTHON_VERSION}/bin/conda clean -a && \
     /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv
-ENV PATH /opt/python/${PYTHON_VERSION}/bin:$PATH
 
 # Install other Python PyPi packages
 RUN pip install --no-cache-dir \
@@ -44,7 +43,6 @@ RUN pip install --no-cache-dir \
 
 # Add binaries to the PATH
 RUN \
-    ln -s /opt/python/${PYTHON_VERSION}/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     ln -s /opt/python/${PYTHON_VERSION}/bin/python /usr/local/bin/python && \
     ln -s /opt/python/${PYTHON_VERSION}/bin/python3 /usr/local/bin/python3 && \
     ln -s /opt/python/${PYTHON_VERSION}/bin/rsconnect /usr/local/bin/rsconnect && \

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -34,27 +34,19 @@ RUN curl -o /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.5
     /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv
 
 # Install other Python PyPi packages
-RUN pip install --no-cache-dir \
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install --no-cache-dir \
                 pip==20.0.2 \
                 jupyter==1.0.0 \
                 jupyterlab==2.1.0 \
                 rsp_jupyter==1.2.5003 \
                 rsconnect_jupyter==1.3.3.1
 
-# Add binaries to the PATH
-RUN \
-    ln -s /opt/python/${PYTHON_VERSION}/bin/python /usr/local/bin/python && \
-    ln -s /opt/python/${PYTHON_VERSION}/bin/python3 /usr/local/bin/python3 && \
-    ln -s /opt/python/${PYTHON_VERSION}/bin/rsconnect /usr/local/bin/rsconnect && \
-    ln -s /opt/python/${PYTHON_VERSION}/bin/virtualenv /usr/local/bin/virtualenv && \
-    ln -s /opt/python/${PYTHON_VERSION}/bin/conda /usr/local/bin/conda
-
 # Install Jupyter extensions
-RUN jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
-    jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
-    jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
-    jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
-    jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter && \
+    /opt/python/${PYTHON_VERSION}/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 # Runtime settings ------------------------------------------------------------#
 ARG TINI_VERSION=0.18.0

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -30,8 +30,6 @@ RUN curl -o /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.5
     /bin/bash /tmp/miniconda.sh -b -p /opt/python/${PYTHON_VERSION} && \
     rm /tmp/miniconda.sh && \
     /opt/python/${PYTHON_VERSION}/bin/conda clean -tipsy && \
-    ln -s /opt/python/${PYTHON_VERSION}/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo "PATH=/opt/python/${PYTHON_VERSION}/bin:$PATH" > /etc/profile.d/python.sh && \
     /opt/python/${PYTHON_VERSION}/bin/conda clean -a && \
     /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv
 ENV PATH /opt/python/${PYTHON_VERSION}/bin:$PATH
@@ -43,6 +41,15 @@ RUN pip install --no-cache-dir \
                 jupyterlab==2.1.0 \
                 rsp_jupyter==1.2.5003 \
                 rsconnect_jupyter==1.3.3.1
+
+# Add binaries to the PATH
+RUN \
+    ln -s /opt/python/${PYTHON_VERSION}/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    ln -s /opt/python/${PYTHON_VERSION}/bin/python /usr/local/bin/python && \
+    ln -s /opt/python/${PYTHON_VERSION}/bin/python3 /usr/local/bin/python3 && \
+    ln -s /opt/python/${PYTHON_VERSION}/bin/rsconnect /usr/local/bin/rsconnect && \
+    ln -s /opt/python/${PYTHON_VERSION}/bin/virtualenv /usr/local/bin/virtualenv && \
+    ln -s /opt/python/${PYTHON_VERSION}/bin/conda /usr/local/bin/conda
 
 # Install Jupyter extensions
 RUN jupyter-nbextension install --sys-prefix --py rsp_jupyter && \

--- a/server-pro/conf/launcher-env
+++ b/server-pro/conf/launcher-env
@@ -2,3 +2,5 @@ JobType: session
 Environment: LANG=en_US.UTF-8
     LANGUAGE=en_US:en
     LC_ALL=en_US.UTF-8
+JobType: any
+Environment: PATH=/opt/python/3.6.5/bin:$PATH

--- a/server-pro/test/goss.yaml
+++ b/server-pro/test/goss.yaml
@@ -35,6 +35,12 @@ command:
       "/{{ .Env.RSP_VERSION }}/",
       "/Pro/"
     ]
-  "echo '{ \"cells\": [], \"metadata\": {}, \"nbformat\": 4, \"nbformat_minor\": 2}' | jupyter nbconvert --to notebook --stdin --stdout":
+  "echo '{ \"cells\": [], \"metadata\": {}, \"nbformat\": 4, \"nbformat_minor\": 2}' | /opt/python/3.6.5/bin/jupyter nbconvert --to notebook --stdin --stdout":
     title: jupyter_works
     exit-status: 0
+  "which openssl":
+    title: uses_system_openssl
+    exit-status: 0
+    stdout: [
+      "/usr/bin/openssl"
+    ]


### PR DESCRIPTION
Close #49 

adding `/opt/python/x.x.x/bin/` to the path overwrites the system `openssl`, which can be problematic for certificate verification, updates, etc.