### PR TITLE
switch CRAN to the RSPM URL

### DIFF
--- a/server-pro/conf/repos.conf
+++ b/server-pro/conf/repos.conf
@@ -1,2 +1,2 @@
 RSPM=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
-CRAN=https://cran.rstudio.com
+CRAN=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest


### PR DESCRIPTION
CRAN was disabling RSPM binaries, so I have switched both to point to RSPM