### PR TITLE
add libuser for user creation as a session image

### DIFF
--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -21,7 +21,10 @@ RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends \
         libxrender1 \
         libssl1.0.0 \
         libssl-dev \
+        libuser \
+        libuser1-dev \
         openssh-client \
+        rrdtool \
         wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
If you use the rstudio/rstudio-server-pro image as a "session" image, it complains about libuser not being present. It's not clear to me whether libuser should be a part of RSP in general, but I thought it might be a worthwhile case to make some of the session image management easier in a Kubernetes context