### PR TITLE
RSC Centos7 image 

### DIFF
--- a/connect/centos7/Dockerfile
+++ b/connect/centos7/Dockerfile
@@ -1,0 +1,79 @@
+ARG R_VERSION=3.6.2
+FROM rstudio/r-base:${R_VERSION}-centos7
+LABEL maintainer="RStudio Docker <docker@rstudio.com>"
+
+# Locale configuration --------------------------------------------------------#
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+# Not needed for centos
+#ENV DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008,DL3009
+# RUN apt-get update --fix-missing \
+#     && apt-get install -y --no-install-recommends \
+#         wget \
+#         bzip2 \
+#         ca-certificates \
+#         libglib2.0-0 \
+#         libxext6 \
+#         libsm6 \
+#         libxrender1 \
+#         gdebi-core \
+#         libssl1.0.0 \
+#         libssl-dev git \
+# 	sudo \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
+
+# install sys deps    
+# bzip2 missing and needed for python install
+RUN yum install -y epel-release
+RUN yum install -y bzip2 perl make libpng-devel libsodium-devel tcl tk tk-devel java-1.8.0-openjdk-devel libjpeg-turbo-devel libcurl-devel openssl-devel ImageMagick ImageMagick-c++-devel libxml2-devel cairo-devel git geos-devel unixODBC-devel libicu-devel glpk-devel gmp-devel v8-devel mariadb-devel fontconfig-devel freetype-devel libgit2-devel libssh2-devel zlib-devel gdal-devel gdal proj-devel proj-epsg libtiff-devel fribidi-devel harfbuzz-devel udunits2-devel mesa-libGLU-devel mesa-libGL-devel
+
+
+
+# Install Python  -------------------------------------------------------------#
+ARG PYTHON_VERSION=3.6.5
+RUN curl -o /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh && \
+    /bin/bash /tmp/miniconda.sh -b -p /opt/python/${PYTHON_VERSION} && \
+    rm /tmp/miniconda.sh && \
+    /opt/python/${PYTHON_VERSION}/bin/conda clean -tipsy && \
+    ln -s /opt/python/${PYTHON_VERSION}/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo "PATH=/opt/python/${PYTHON_VERSION}/bin:$PATH" > /etc/profile.d/python.sh && \
+    /opt/python/${PYTHON_VERSION}/bin/conda clean -a && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install 'virtualenv<20' && \
+    /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade setuptools
+ENV PATH /opt/python/${PYTHON_VERSION}/bin:$PATH
+
+# Runtime settings ------------------------------------------------------------#
+ARG TINI_VERSION=0.18.0
+RUN curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini && \
+    chmod +x /usr/local/bin/tini
+
+COPY startup.sh /usr/local/bin/startup.sh
+RUN chmod +x /usr/local/bin/startup.sh
+
+# Download RStudio Connect -----------------------------------------------------#
+ARG RSC_VERSION=1.8.8
+# RUN apt-get update --fix-missing \
+#     && curl -L -o rstudio-connect.deb https://cdn.rstudio.com/connect/$(echo $RSC_VERSION | sed -r 's/([0-9]\.[0-9]\.[0-9]).*/\1/')/rstudio-connect_${RSC_VERSION}~ubuntu18_amd64.deb \
+#     && gdebi -n rstudio-connect.deb \
+#     && rm -rf rstudio-connect.deb \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
+  
+# Centos Commands  
+RUN curl -L -o rstudio-connect.rpm https://cdn.rstudio.com/connect/$(echo $RSC_VERSION | sed -r 's/([0-9]\.[0-9]\.[0-9]).*/\1/')/rstudio-connect-${RSC_VERSION}.el7.x86_64.rpm \
+    && sudo yum -y install rstudio-connect.rpm \
+    && rm -rf rstudio-connect.rpm
+
+EXPOSE 3939/tcp
+ENV RSC_LICENSE ""
+ENV RSC_LICENSE_SERVER ""
+COPY rstudio-connect.gcfg /etc/rstudio-connect/rstudio-connect.gcfg
+VOLUME ["/data"]
+
+ENTRYPOINT ["tini", "--"]
+CMD ["/usr/local/bin/startup.sh"]

--- a/connect/centos7/Dockerfile
+++ b/connect/centos7/Dockerfile
@@ -7,32 +7,12 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-# Not needed for centos
-#ENV DEBIAN_FRONTEND=noninteractive
 
-# hadolint ignore=DL3008,DL3009
-# RUN apt-get update --fix-missing \
-#     && apt-get install -y --no-install-recommends \
-#         wget \
-#         bzip2 \
-#         ca-certificates \
-#         libglib2.0-0 \
-#         libxext6 \
-#         libsm6 \
-#         libxrender1 \
-#         gdebi-core \
-#         libssl1.0.0 \
-#         libssl-dev git \
-# 	sudo \
-#     && apt-get clean \
-#     && rm -rf /var/lib/apt/lists/*
-
-# install sys deps    
-# bzip2 missing and needed for python install
+# Sys dep installation --------------------------------------------------------#
+# install sys deps as defined at https://docs.rstudio.com/rsc/manual-install/
+# bzip2 added for miniconda install
 RUN yum install -y epel-release
 RUN yum install -y bzip2 perl make libpng-devel libsodium-devel tcl tk tk-devel java-1.8.0-openjdk-devel libjpeg-turbo-devel libcurl-devel openssl-devel ImageMagick ImageMagick-c++-devel libxml2-devel cairo-devel git geos-devel unixODBC-devel libicu-devel glpk-devel gmp-devel v8-devel mariadb-devel fontconfig-devel freetype-devel libgit2-devel libssh2-devel zlib-devel gdal-devel gdal proj-devel proj-epsg libtiff-devel fribidi-devel harfbuzz-devel udunits2-devel mesa-libGLU-devel mesa-libGL-devel
-
-
 
 # Install Python  -------------------------------------------------------------#
 ARG PYTHON_VERSION=3.6.5
@@ -57,14 +37,6 @@ RUN chmod +x /usr/local/bin/startup.sh
 
 # Download RStudio Connect -----------------------------------------------------#
 ARG RSC_VERSION=1.8.8
-# RUN apt-get update --fix-missing \
-#     && curl -L -o rstudio-connect.deb https://cdn.rstudio.com/connect/$(echo $RSC_VERSION | sed -r 's/([0-9]\.[0-9]\.[0-9]).*/\1/')/rstudio-connect_${RSC_VERSION}~ubuntu18_amd64.deb \
-#     && gdebi -n rstudio-connect.deb \
-#     && rm -rf rstudio-connect.deb \
-#     && apt-get clean \
-#     && rm -rf /var/lib/apt/lists/*
-  
-# Centos Commands  
 RUN curl -L -o rstudio-connect.rpm https://cdn.rstudio.com/connect/$(echo $RSC_VERSION | sed -r 's/([0-9]\.[0-9]\.[0-9]).*/\1/')/rstudio-connect-${RSC_VERSION}.el7.x86_64.rpm \
     && sudo yum -y install rstudio-connect.rpm \
     && rm -rf rstudio-connect.rpm

--- a/connect/centos7/docker-compose.test.yml
+++ b/connect/centos7/docker-compose.test.yml
@@ -1,0 +1,14 @@
+version: '2.3'
+services:
+
+  sut:
+    image: $IMAGE_NAME
+    command: /run_tests.sh
+    entrypoint: []
+    privileged: true
+    environment:
+      # uses .env by default
+      - RSC_VERSION
+    volumes:
+      - "./test/run_tests.sh:/run_tests.sh"
+      - "./test/goss.yaml:/tmp/goss.yaml"

--- a/connect/centos7/hooks/build
+++ b/connect/centos7/hooks/build
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+echo '--> Showing .env file'
+cat .env
+
+# use xargs -0 (BSD) or xargs -d '\n' (GNU) to read env vars with spaces
+# https://stackoverflow.com/questions/19331497/set-environment-variables-from-file-of-key-value-pairs
+export $(grep -v '^#' .env | xargs)
+
+echo '--> Showing Environment Variables'
+echo "RSC_VERSION=${RSC_VERSION}"
+echo "IMAGE_NAME=${IMAGE_NAME}"
+echo "DOCKERFILE_PATH=${DOCKERFILE_PATH}"
+
+echo ""
+echo "SOURCE_BRANCH=${SOURCE_BRANCH}"
+echo "SOURCE_COMMIT=${SOURCE_COMMIT}"
+echo "COMMIT_MSG=${COMMIT_MSG}"
+echo "DOCKER_REPO=${DOCKER_REPO}"
+echo "DOCKER_TAG=${DOCKER_TAG}"
+
+docker build --build-arg RSC_VERSION=${RSC_VERSION} -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/connect/centos7/hooks/post_push
+++ b/connect/centos7/hooks/post_push
@@ -1,0 +1,28 @@
+#!/bin/bash
+# adapted from: https://windsock.io/automated-docker-image-builds-with-multiple-tags/
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)
+imageStart=$(expr index "$IMAGE_NAME" /)
+
+repoName=${IMAGE_NAME:0:tagStart-1}
+imageName=${IMAGE_NAME:imageStart:${#IMAGE_NAME}-tagStart-1}
+
+if [ "${DOCKER_TAG}" != "latest" ] && [[ "${repoName}" != *"preview"* ]]; then
+  echo "Non-latest build - exiting and not tagging version number"
+  exit 0
+fi
+
+# use xargs -0 (BSD) or xargs -d '\n' (GNU) to read env vars with spaces
+# https://stackoverflow.com/questions/19331497/set-environment-variables-from-file-of-key-value-pairs
+export $(grep -v '^#' .env | xargs)
+tag=${RSC_VERSION}
+
+echo "Pushing tag: ${repoName}:${tag}"
+
+if [ -n "$tag" ]; then
+  docker tag $IMAGE_NAME ${repoName}:${tag}
+  docker push ${repoName}:${tag}
+fi

--- a/connect/centos7/hooks/pre_build
+++ b/connect/centos7/hooks/pre_build
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+echo "Building DOCKER_TAG=${DOCKER_TAG}"
+
+apt-get update -qq && apt-get install -y jq
+
+replace_version() {
+  sed -i.bak "s/^RSC_VERSION=.*/RSC_VERSION=$1/g" ./.env
+}
+
+# if daily build
+# replace version number and download url
+if [[ "${DOCKER_TAG}" == *"daily"* ]]; then
+  echo "--> Running daily"
+  # get daily version
+  rawurl=`curl -s https://cdn.rstudio.com/connect/latest-packages.json | jq -r '.packages | map(select(.platform == "ubuntu18/amd64"))[0].url'`
+
+  
+  echo "Got raw URL: $rawurl"
+  # thanks to https://stackoverflow.com/a/44490624/6570011
+  if [[ "$rawurl" =~ \_([a-z0-9\.\-]*) ]]; then
+    match="${BASH_REMATCH[1]}"
+    echo "Latest version found: $match"
+    replace_version $match
+  else
+    # fail the build
+    echo "ERROR parsing latest daily version"
+    exit 1
+  fi
+
+elif [[ "${DOCKER_TAG}" =~ [0-9\.\-]+ ]]; then
+  echo "DOCKER_TAG looks like a version number: ${DOCKER_TAG}"
+  echo "Building DOCKER_TAG defined version"
+  replace_version ${DOCKER_TAG}
+else
+  echo "No version customization necessary"
+fi
+
+echo '--> Showing .env file'
+cat .env

--- a/connect/centos7/rstudio-connect-float.gcfg
+++ b/connect/centos7/rstudio-connect-float.gcfg
@@ -1,0 +1,43 @@
+; RStudio Connect configuration file
+
+[Licensing]
+LicenseType = remote
+
+[Server]
+; SenderEmail is an email address used by RStudio Connect to send outbound
+; email. The system will not be able to send administrative email until this
+; setting is configured.
+;
+; SenderEmail = account@company.com
+; The public URL to this RStudio Connect container. This might the address for
+; a proxy or the host running the Docker container.
+; Address = https://rstudio-connect.company.com
+
+; The persistent data directory mounted into our container.
+DataDir = /data
+
+; Address is a public URL for this RStudio Connect server. Must be configured
+; to enable features like including links to your content in emails. If
+; Connect is deployed behind an HTTP proxy, this should be the URL for Connect
+; in terms of that proxy.
+;
+; Address = https://rstudio-connect.company.com
+Address =
+
+[HTTP]
+; RStudio Connect will listen on this network address for HTTP connections.
+Listen = :3939
+
+[Authentication]
+; Specifies the type of user authentication.
+Provider = password
+
+[Python]
+Enabled = true
+Executable = /opt/python/3.6.5/bin/python
+
+;[RPackageRepository "CRAN"]
+;URL = https://demo.rstudiopm.com/all/__linux__/bionic/latest
+;
+;[RPackageRepository "RSPM"]
+;URL = https://demo.rstudiopm.com/all/__linux__/bionic/latest

--- a/connect/centos7/rstudio-connect-float.gcfg
+++ b/connect/centos7/rstudio-connect-float.gcfg
@@ -37,7 +37,7 @@ Enabled = true
 Executable = /opt/python/3.6.5/bin/python
 
 ;[RPackageRepository "CRAN"]
-;URL = https://demo.rstudiopm.com/all/__linux__/bionic/latest
+;URL = https://demo.rstudiopm.com/all/__linux__/centos7/latest
 ;
 ;[RPackageRepository "RSPM"]
-;URL = https://demo.rstudiopm.com/all/__linux__/bionic/latest
+;URL = https://demo.rstudiopm.com/all/__linux__/centos7/latest

--- a/connect/centos7/rstudio-connect.gcfg
+++ b/connect/centos7/rstudio-connect.gcfg
@@ -33,7 +33,7 @@ Enabled = true
 Executable = /opt/python/3.6.5/bin/python
 
 [RPackageRepository "CRAN"]
-URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+URL = https://packagemanager.rstudio.com/cran/__linux__/centos7/latest
 
 [RPackageRepository "RSPM"]
-URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+URL = https://packagemanager.rstudio.com/cran/__linux__/centos7/latest

--- a/connect/centos7/rstudio-connect.gcfg
+++ b/connect/centos7/rstudio-connect.gcfg
@@ -1,0 +1,39 @@
+; RStudio Connect configuration file
+
+[Server]
+; SenderEmail is an email address used by RStudio Connect to send outbound
+; email. The system will not be able to send administrative email until this
+; setting is configured.
+;
+; SenderEmail = account@company.com
+
+; The persistent data directory mounted into our container.
+DataDir = /data
+
+; Address is a public URL for this RStudio Connect server. Must be configured
+; to enable features like including links to your content in emails. If
+; Connect is deployed behind an HTTP proxy, this should be the URL for Connect
+; in terms of that proxy.
+;
+; Address = https://rstudio-connect.company.com
+
+; Placeholder value. Please replace
+Address = http://localhost:3939
+
+[HTTP]
+; RStudio Connect will listen on this network address for HTTP connections.
+Listen = :3939
+
+[Authentication]
+; Specifies the type of user authentication.
+Provider = password
+
+[Python]
+Enabled = true
+Executable = /opt/python/3.6.5/bin/python
+
+[RPackageRepository "CRAN"]
+URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+
+[RPackageRepository "RSPM"]
+URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest

--- a/connect/centos7/startup.sh
+++ b/connect/centos7/startup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Deactivate license when it exists
+deactivate() {
+    echo "Deactivating license ..."
+    /opt/rstudio-connect/bin/license-manager deactivate >/dev/null 2>&1
+}
+trap deactivate EXIT
+
+# Activate License
+if ! [ -z "$RSC_LICENSE" ]; then
+    /opt/rstudio-connect/bin/license-manager activate $RSC_LICENSE
+elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
+    /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
+elif test -f "/etc/rstudio-connect/license.lic"; then
+    /opt/rstudio-connect/bin/license-manager activate-file /etc/rstudio-connect/license.lic
+fi
+
+# lest this be inherited by child processes
+unset RSC_LICENSE
+unset RSC_LICENSE_SERVER
+
+# Start RStudio Connect
+/opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg

--- a/connect/centos7/test/goss.yaml
+++ b/connect/centos7/test/goss.yaml
@@ -1,0 +1,49 @@
+user:
+  rstudio-connect:
+    exists: true
+    uid: 999
+    gid: 999
+
+group:
+  rstudio-connect:
+    exists: true
+    gid: 999
+
+package:
+  rstudio-connect:
+    installed: true
+
+file:
+  /etc/rstudio-connect/license.lic:
+    # currently does not exist
+    # be sure it is NOT a directory
+    exists: false
+  /opt/rstudio-connect/:
+    exists: true
+  /opt/rstudio-connect/bin/connect:
+    exists: true
+
+# check product version
+command:
+  "/opt/rstudio-connect/bin/connect --version":
+    title: connect_version_matches
+    exit-status: 0
+    stdout: [
+      "/{{ .Env.RSC_VERSION }}/"
+    ]
+  # goss times out after 10 seconds
+  "timeout --signal=SIGINT 7 /opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg":
+    title: connect_starts
+    # the timeout should stop connect, not a failure
+    exit-status: 124
+    # maybe optimistic that Connect finishes starting...
+    #stderr: [
+    #  "Starting HTTP listener on :3939"
+    #]
+  "/opt/R/3.6.2/bin/R --version":
+    title: r_version_match
+    exit-status: 0
+    stdout: [
+      "/3.6.2/"
+    ]
+

--- a/connect/centos7/test/run_tests.sh
+++ b/connect/centos7/test/run_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# install goss
+
+GOSS_FILE=${GOSS_FILE:-/tmp/goss.yaml}
+GOSS_VARS=${GOSS_VARS:-/tmp/goss_vars.yaml}
+GOSS_VERSION=${GOSS_VERSION:-0.3.8}
+GOSS_MAX_CONCURRENT=${GOSS_MAX_CONCURRENT:-50}
+
+# default to empty var file (since vars are not necessary)
+if [ ! -f "$GOSS_VARS" ]; then
+  touch $GOSS_VARS
+fi
+
+# install goss to tmp location and make executable
+curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+  && chmod +x /tmp/goss \
+  && GOSS=/tmp/goss
+
+GOSS_FILE=$GOSS_FILE GOSS_VARS=$GOSS_VARS $GOSS v --format documentation --max-concurrent $GOSS_MAX_CONCURRENT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,23 @@ services:
       - ./connect/rstudio-connect.gcfg:/etc/rstudio-connect/rstudio-connect.gcfg
       - ./data/rsc:/data
 
+  rstudio-connect-centos7:
+    build:
+      context: ./connect/centos7
+      args:
+        RSC_VERSION: 1.8.8
+    image: rstudio/rstudio-connect:1.8.8
+    privileged: true
+    environment:
+      RSC_LICENSE: ${RSC_LICENSE}
+      LICENSE_SERVER: ${RSC_LICENSE_SERVER}
+    ports:
+      - 3939:3939
+    volumes:
+      - ./connect/rstudio-connect.gcfg:/etc/rstudio-connect/rstudio-connect.gcfg
+      - ./data/rsc:/data
+
+
   rstudio-package-manager:
     build:
       context: ./package-manager


### PR DESCRIPTION
The pull request creates an RSC centos7 image. It is stored under `/connect/centos7`. It leaves the remaining directory structure in tact so at not to interfere with the docker build process. 

Of note, this docker image is 3gb as opposed to the existing one which is 1.7gb. I suspect this is due to the inclusion of sys deps as outlined at https://docs.rstudio.com/rsc/manual-install/. 

Files modified:

- `docker-compose.yml`: created new image named `rstudio-connect-centos7` which is built from the context `./connect/centos7`

Files added:

- `./connect/centos7/`: all files unchanged except `Dockerfile` and config files
- `Dockerfile`: uses `rstudio/r-base:${R_VERSION}-centos7` as the base image. Installs recommended sys deps from manual install and RSC. Everything else unchanged. 
- `rstudio-connect.gcfg` and `rstudio-connect-float.gcfg` are modified to use centos7 binaries. 