### PR TITLE
good virtualenv for python2.7

### DIFF
--- a/content-base/bionic/Dockerfile
+++ b/content-base/bionic/Dockerfile
@@ -114,8 +114,7 @@ ARG PYTHON_VERSION=3.7.6
 RUN curl -fsSL -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh \
     && chmod 755 miniconda.sh \
     && ./miniconda.sh -b -p /opt/miniconda \
-    && /opt/miniconda/bin/conda create --quiet --yes --prefix /opt/python/${PYTHON_VERSION} --channel conda-forge python=${PYTHON_VERSION} \
-    && /opt/python/${PYTHON_VERSION}/bin/pip install virtualenv \
+    && /opt/miniconda/bin/conda create --quiet --yes --prefix /opt/python/${PYTHON_VERSION} --channel conda-forge python=${PYTHON_VERSION} virtualenv \
     && rm -f miniconda.sh \
     # remove miniconda too, for size
     && rm -rf /opt/miniconda


### PR DESCRIPTION
Don't have a clear root cause, but this is enough to get past the libpython load problems.

Without this change:

```console
/opt/python/2.7.18/bin/python -m virtualenv --version
# => virtualenv 20.4.7 from /opt/python/2.7.18/lib/python2.7/site-packages/virtualenv/__init__.pyc
/opt/python/2.7.18/bin/python -m pip --version
# => pip 20.1.1 from /opt/python/2.7.18/lib/python2.7/site-packages/pip (python 2.7)
/opt/python/2.7.18/bin/python -m virtualenv /tmp/target --python /opt/python/2.7.18/bin/python --system-site-packages
# ... NOT VERY MUCH OUTPUT
/tmp/target/bin/python --version
# => /tmp/target/bin/python: error while loading shared libraries: libpython2.7.so.1.0: cannot open shared object file: No such file or directory
```

With this change:

```console
/opt/python/2.7.18/bin/python -m virtualenv --version
# => 16.7.5
/opt/python/2.7.18/bin/python -m pip --version
# => pip 20.1.1 from /opt/python/2.7.18/lib/python2.7/site-packages/pip (python 2.7)
/opt/python/2.7.18/bin/python -m virtualenv /tmp/target --python /opt/python/2.7.18/bin/python --system-site-packages
# ... VAST AMOUNTS OF OUTPUT
/tmp/target/bin/python --version
# => Python 2.7.18 :: Anaconda, Inc.
```

