### PR TITLE
add a daily cron

### DIFF
--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -5,6 +5,10 @@ on:
         description: "Which images to build. Default 'all'. Options: 'all','rstudio-workbench-preview','rstudio-connect-preview','rstudio-connect-content-init-preview','r-session-complete-preview'. Can also use a prefix (i.e. 'rstudio-connect') to trigger multiple image builds."
         required: true
         default: "all"
+      version:
+        description: "The version to build. Default 'auto'. Can use any string, but must have which != 'all' if using something other than 'auto'"
+        required: false
+        default: "auto"
 
 name: build/test/push (preview)
 jobs:
@@ -12,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: build-${{ matrix.config.tag_prefix}}${{ matrix.config.product}}
-    if: ${{ github.events.inputs.which == 'all' || startsWith(matrix.config.product, github.events.inputs.which) }}
+    if: ${{ (github.events.inputs.which == 'all' || startsWith(matrix.config.product, github.events.inputs.which) ) && (github.events.inputs.version == 'auto' || github.events.inputs.which != 'all') }}
 
     strategy:
       fail-fast: false
@@ -39,7 +43,7 @@ jobs:
         id: version
         run: |
           # NOTE: --local ensures that "latest" builds use the version in our Makefile (instead of latest from the web)
-          VERSION=`./get-version.py ${{ matrix.config.product }} --type=${{ matrix.config.version }} --local`
+          VERSION=`./get-version.py ${{ matrix.config.product }} --type=${{ matrix.config.version }} --local --override=${{ github.events.inputs.version }}`
           echo "::set-output name=VERSION::${VERSION}"
 
       - name: Cache Docker layers

--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -1,0 +1,114 @@
+on:
+  workflow_dispatch:
+    inputs:
+      which:
+        description: "Which images to build. Default 'all'. Options: 'all','rstudio-workbench-preview','rstudio-connect-preview','rstudio-connect-content-init-preview','r-session-complete-preview'"
+        required: true
+        default: "all"
+
+name: build/test/push (preview)
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    name: build-${{ matrix.config.tag_prefix}}${{ matrix.config.product}}
+    if: ${{ github.events.inputs.which == 'all' || github.events.inputs.which == matrix.config.product }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {product: 'rstudio-workbench-preview', dir: 'server-pro', prefix: RSP, os: 'bionic/amd64', version: 'daily'}
+          - {product: 'rstudio-workbench-preview', dir: 'server-pro', prefix: RSP, os: 'bionic/amd64', version: 'preview'}
+          - {product: 'rstudio-connect-preview', dir: 'connect', prefix: RSC, version: 'daily'}
+          - {product: 'rstudio-connect-content-init-preview', dir: 'connect-content-init', prefix: RSC, version: 'daily'}
+          - {product: 'r-session-complete-preview', tag_prefix: 'bionic-', dir: 'r-session-complete/bionic', os: 'bionic/amd64', prefix: RSP, version: 'daily'}
+          - {product: 'r-session-complete-preview', tag_prefix: 'centos7-', dir: 'r-session-complete/centos7', os: 'centos7/x86_64', prefix: RSP, version: 'daily'}
+          - {product: 'r-session-complete-preview', tag_prefix: 'bionic-', dir: 'r-session-complete/bionic', os: 'bionic/amd64', prefix: RSP, version: 'preview'}
+          - {product: 'r-session-complete-preview', tag_prefix: 'centos7-', dir: 'r-session-complete/centos7', os: 'centos7/x86_64', prefix: RSP, version: 'preview'}
+
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Get version
+        id: version
+        run: |
+          # NOTE: --local ensures that "latest" builds use the version in our Makefile (instead of latest from the web)
+          VERSION=`./get-version.py ${{ matrix.config.product }} --type=${{ matrix.config.version }} --local`
+          echo "::set-output name=VERSION::${VERSION}"
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./${{ matrix.config.dir }}
+          file: ./${{ matrix.config.dir }}/Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          tags: |
+            rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
+            rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.VERSION }}
+            ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
+            ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.VERSION }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          load: true
+          push: false
+          build-args: |
+            RSP_VERSION=${{ steps.version.outputs.VERSION }}
+            RSC_VERSION=${{ steps.version.outputs.VERSION }}
+            RSPM_VERSION=${{ steps.version.outputs.VERSION }}
+            # TODO: need a better way to handle pivoting DOWNLOAD_URL for OS
+            RSP_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/${{ matrix.config.os }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Show image size
+        run: |
+          docker image ls
+
+      - name: Test image
+        env:
+          IMAGE_NAME: rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
+          # because we cannot dynamically set env var names... set them all...
+          RSP_VERSION: ${{ steps.version.outputs.VERSION }}
+          RSC_VERSION: ${{ steps.version.outputs.VERSION }}
+          RSPM_VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          docker-compose -f ./${{ matrix.config.dir }}/docker-compose.test.yml run sut
+
+      - name: Login to Docker Hub
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Login to ghcr.io
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.BUILD_PAT }}
+
+      - name: Push image(s) to Docker Hub
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          docker push rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
+          docker push rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.VERSION }}
+          docker push ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
+          docker push ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -2,7 +2,7 @@ on:
   workflow_dispatch:
     inputs:
       which:
-        description: "Which images to build. Default 'all'. Options: 'all','rstudio-workbench-preview','rstudio-connect-preview','rstudio-connect-content-init-preview','r-session-complete-preview'"
+        description: "Which images to build. Default 'all'. Options: 'all','rstudio-workbench-preview','rstudio-connect-preview','rstudio-connect-content-init-preview','r-session-complete-preview'. Can also use a prefix (i.e. 'rstudio-connect') to trigger multiple image builds."
         required: true
         default: "all"
 
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: build-${{ matrix.config.tag_prefix}}${{ matrix.config.product}}
-    if: ${{ github.events.inputs.which == 'all' || github.events.inputs.which == matrix.config.product }}
+    if: ${{ github.events.inputs.which == 'all' || startsWith(matrix.config.product, github.events.inputs.which) }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -9,6 +9,12 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      which:
+        description: "Which images to build. Default 'all'. Options: 'all','rstudio-workbench-preview','rstudio-connect-preview','rstudio-connect-content-init-preview','r-session-complete-preview'"
+        required: true
+        default: "all"
 
 name: build/test/push (preview)
 jobs:
@@ -16,6 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: build-${{ matrix.config.tag_prefix}}${{ matrix.config.product}}
+    if: ${{ github.events.inputs.which == 'all' || github.events.inputs.which == matrix.config.product }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -9,12 +9,6 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      which:
-        description: "Which images to build. Default 'all'. Options: 'all','rstudio-workbench-preview','rstudio-connect-preview','rstudio-connect-content-init-preview','r-session-complete-preview'"
-        required: true
-        default: "all"
 
 name: build/test/push (preview)
 jobs:

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -16,7 +16,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: build-${{ matrix.config.tag_prefix}}${{ matrix.config.product}}
-    if: ${{ github.events.inputs.which == 'all' || github.events.inputs.which == matrix.config.product }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -1,4 +1,8 @@
 on:
+  schedule:
+    # every morning at 8am UTC
+    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
+    - cron: '0 8 * * *'
   push:
     branches:
       - main

--- a/get-version.py
+++ b/get-version.py
@@ -167,10 +167,18 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether to use the 'local' version for 'release'. Parsed from the local Makefile",
     )
+    parser.add_argument(
+        "--override", "-o",
+        type=str,
+        nargs=1,
+        help="Whether to override the version. If set to 'auto' then it has no effect. (default: 'auto')",
+        default=["auto"]
+    )
     args = parser.parse_args()
 
     selected_product = args.product[0]
     version_type = args.type[0]
+    override = args.override[0]
     local = args.local
 
     # ------------------------------------------
@@ -194,10 +202,18 @@ if __name__ == "__main__":
     print(f"Providing version for product: '{selected_product}' and version type: '{version_type}'", file=sys.stderr)
 
     # ------------------------------------------
+    # Use override, if defined
+    # ------------------------------------------
+    if override != 'auto':
+        print("The --override arg was set with a value other than 'auto'", file=sys.stderr)
+        print("Overriding version_type with: 'manual'", file=sys.stderr)
+        version_type = 'manual'
+        print(f"Overriding version with override: '{override}'", file=sys.stderr)
+        version = override
+    # ------------------------------------------
     # Product "switch" statements
     # ------------------------------------------
-
-    if selected_product == 'workbench':
+    elif selected_product == 'workbench':
         if version_type == 'daily':
             version = rstudio_workbench_daily()
         elif version_type == 'preview':


### PR DESCRIPTION
for preview builds

It's possible that we may want to set up a webhook so that Connect (or other products) can tell us when a new build is available / has landed on master 🤷‍♂️ 

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch