### PR TITLE
Add content-base-pro image builds

### DIFF
--- a/content-base/Makefile
+++ b/content-base/Makefile
@@ -15,6 +15,7 @@ DISTRIBUTION=bionic
 TAG_BASE=rstudio/content-base
 R_VERSION=3.6.3
 PYTHON_VERSION=3.7.6
+DRIVERS_VERSION=1.7.0
 
 all: push
 .PHONY: all
@@ -29,9 +30,19 @@ build:
 	docker build --build-arg R_VERSION=$(R_VERSION) --build-arg PYTHON_VERSION=$(PYTHON_VERSION) -t $(TAG_BASE):r$(R_VERSION)-py$(PYTHON_VERSION)-$(DISTRIBUTION) $(DISTRIBUTION)
 .PHONY: build
 
+# Builds the image for a single distribution with pro-drivers installed. Expects that the Dockerfile for
+# this image is in a $DISTRIBUTION/pro sub-directory. This image uses the standard content-base
+# image for the distribution as the FROM image in the dockerfile
+build-pro: build
+	docker build --build-arg R_VERSION=$(R_VERSION) --build-arg DRIVERS_VERSION=$(DRIVERS_VERSION) \
+		--build-arg BASE_IMAGE="$(TAG_BASE):r$(R_VERSION)-py$(PYTHON_VERSION)-$(DISTRIBUTION)" \
+		-t $(TAG_BASE)-pro:r$(R_VERSION)-py$(PYTHON_VERSION)-$(DISTRIBUTION) $(DISTRIBUTION)/pro
+.PHONY: build-pro
+
 # Do not run push if you are not Cole.
-push: build
+push: build-pro
 	docker push $(TAG_BASE):r$(R_VERSION)-py$(PYTHON_VERSION)-$(DISTRIBUTION)
+	docker push $(TAG_BASE)-pro:r$(R_VERSION)-py$(PYTHON_VERSION)-$(DISTRIBUTION)
 .PHONY: push
 
 # Enumeration of image tags for all supported distributions.
@@ -40,4 +51,5 @@ TAGS=$(DISTRIBUTIONS:%=$(TAG_BASE):r$(R_VERSION)-py$(PYTHON_VERSION)-%)
 # Prints the Docker tag associated with the configured image.
 tag:
 	@echo "$(TAG_BASE):r$(R_VERSION)-py$(PYTHON_VERSION)-$(DISTRIBUTION)"
+	@echo "$(TAG_BASE)-pro:r$(R_VERSION)-py$(PYTHON_VERSION)-$(DISTRIBUTION)"
 .PHONY: tag

--- a/content-base/bionic/pro/Dockerfile
+++ b/content-base/bionic/pro/Dockerfile
@@ -1,0 +1,21 @@
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}
+
+MAINTAINER RStudio Docker <docker@rstudio.com>
+
+# Install RStudio Professional Drivers ----------------------------------------#
+ARG DRIVERS_VERSION
+ARG R_VERSION
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y unixodbc unixodbc-dev gdebi && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive gdebi --non-interactive rstudio-drivers_${DRIVERS_VERSION}_amd64.deb && \
+    rm -rf /var/lib/apt/lists/* && \
+    cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+
+RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'


### PR DESCRIPTION
Adds a `build-pro` make target. All pro images are built `FROM` the existing content-base images for each distro (bionic, right now obviously)