### PR TITLE
Add common license file path

### DIFF
--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -11,13 +11,13 @@ deactivate() {
 trap deactivate EXIT
 
 # Activate License
-CONNECT_LICENSE_FILE_PATH=${CONNECT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+RSC_LICENSE_FILE_PATH=${RSC_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$RSC_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate $RSC_LICENSE
 elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
-elif test -f "$CONNECT_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file $CONNECT_LICENSE_FILE_PATH
+elif test -f "$RSC_LICENSE_FILE_PATH"; then
+    /opt/rstudio-connect/bin/license-manager activate-file $RSC_LICENSE_FILE_PATH
 fi
 
 # lest this be inherited by child processes

--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -15,6 +15,8 @@ if ! [ -z "$RSC_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate $RSC_LICENSE
 elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
+elif test -f "/etc/rstudio-licensing/license.lic"; then
+    /opt/rstudio-connect/bin/license-manager activate-file /etc/rstudio-licensing/license.lic
 elif test -f "/etc/rstudio-connect/license.lic"; then
     /opt/rstudio-connect/bin/license-manager activate-file /etc/rstudio-connect/license.lic
 fi

--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -11,14 +11,13 @@ deactivate() {
 trap deactivate EXIT
 
 # Activate License
+CONNECT_LICENSE_FILE_PATH=${CONNECT_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$RSC_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate $RSC_LICENSE
 elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
-elif test -f "/etc/rstudio-licensing/license.lic"; then
-    /opt/rstudio-connect/bin/license-manager activate-file /etc/rstudio-licensing/license.lic
-elif test -f "/etc/rstudio-connect/license.lic"; then
-    /opt/rstudio-connect/bin/license-manager activate-file /etc/rstudio-connect/license.lic
+elif test -f "$CONNECT_LICENSE_FILE_PATH"; then
+    /opt/rstudio-connect/bin/license-manager activate-file $CONNECT_LICENSE_FILE_PATH
 fi
 
 # lest this be inherited by child processes

--- a/package-manager/startup.sh
+++ b/package-manager/startup.sh
@@ -15,6 +15,8 @@ if ! [ -z "$RSPM_LICENSE" ]; then
     /opt/rstudio-pm/bin/license-manager activate $RSPM_LICENSE
 elif ! [ -z "$RSPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server $RSPM_LICENSE_SERVER
+elif test -f "/etc/rstudio-licensing/license.lic"; then
+    /opt/rstudio-pm/bin/license-manager activate-file /etc/rstudio-licensing/license.lic
 elif test -f "/etc/rstudio-pm/license.lic"; then
     /opt/rstudio-pm/bin/license-manager activate-file /etc/rstudio-pm/license.lic
 fi

--- a/package-manager/startup.sh
+++ b/package-manager/startup.sh
@@ -11,14 +11,13 @@ deactivate() {
 trap deactivate EXIT
 
 # Activate License
+RSPM_LICENSE_FILE_PATH=${RSPM_LICENSE_FILE_PATH:-/etc/rstudio-pm/license.lic}
 if ! [ -z "$RSPM_LICENSE" ]; then
     /opt/rstudio-pm/bin/license-manager activate $RSPM_LICENSE
 elif ! [ -z "$RSPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server $RSPM_LICENSE_SERVER
-elif test -f "/etc/rstudio-licensing/license.lic"; then
-    /opt/rstudio-pm/bin/license-manager activate-file /etc/rstudio-licensing/license.lic
-elif test -f "/etc/rstudio-pm/license.lic"; then
-    /opt/rstudio-pm/bin/license-manager activate-file /etc/rstudio-pm/license.lic
+elif test -f "$RSPM_LICENSE_FILE_PATH"; then
+    /opt/rstudio-pm/bin/license-manager activate-file $RSPM_LICENSE_FILE_PATH
 fi
 
 # lest this be inherited by child processes

--- a/server-pro/startup.sh
+++ b/server-pro/startup.sh
@@ -49,6 +49,8 @@ if ! [ -z "$RSP_LICENSE" ]; then
     /usr/lib/rstudio-server/bin/license-manager activate $RSP_LICENSE
 elif ! [ -z "$RSP_LICENSE_SERVER" ]; then
     /usr/lib/rstudio-server/bin/license-manager license-server $RSP_LICENSE_SERVER
+elif test -f "/etc/rstudio-licensing/license.lic"; then
+    /usr/lib/rstudio-server/bin/license-manager activate-file /etc/rstudio-licensing/license.lic
 elif test -f "/etc/rstudio-server/license.lic"; then
     /usr/lib/rstudio-server/bin/license-manager activate-file /etc/rstudio-server/license.lic
 fi

--- a/server-pro/startup.sh
+++ b/server-pro/startup.sh
@@ -45,14 +45,13 @@ chown rstudio-server:rstudio-server /var/lib/rstudio-launcher/Kubernetes
 su rstudio-server -c 'touch /var/lib/rstudio-launcher/Kubernetes/rstudio-kubernetes-launcher.log'
 
 # Activate License
+RSTUDIO_LICENSE_FILE_PATH=${RSTUDIO_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}
 if ! [ -z "$RSP_LICENSE" ]; then
     /usr/lib/rstudio-server/bin/license-manager activate $RSP_LICENSE
 elif ! [ -z "$RSP_LICENSE_SERVER" ]; then
     /usr/lib/rstudio-server/bin/license-manager license-server $RSP_LICENSE_SERVER
-elif test -f "/etc/rstudio-licensing/license.lic"; then
-    /usr/lib/rstudio-server/bin/license-manager activate-file /etc/rstudio-licensing/license.lic
-elif test -f "/etc/rstudio-server/license.lic"; then
-    /usr/lib/rstudio-server/bin/license-manager activate-file /etc/rstudio-server/license.lic
+elif test -f "$RSTUDIO_LICENSE_FILE_PATH"; then
+    /usr/lib/rstudio-server/bin/license-manager activate-file $RSTUDIO_LICENSE_FILE_PATH
 fi
 
 # lest this be inherited by child processes

--- a/server-pro/startup.sh
+++ b/server-pro/startup.sh
@@ -45,13 +45,13 @@ chown rstudio-server:rstudio-server /var/lib/rstudio-launcher/Kubernetes
 su rstudio-server -c 'touch /var/lib/rstudio-launcher/Kubernetes/rstudio-kubernetes-launcher.log'
 
 # Activate License
-RSTUDIO_LICENSE_FILE_PATH=${RSTUDIO_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}
+RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}
 if ! [ -z "$RSP_LICENSE" ]; then
     /usr/lib/rstudio-server/bin/license-manager activate $RSP_LICENSE
 elif ! [ -z "$RSP_LICENSE_SERVER" ]; then
     /usr/lib/rstudio-server/bin/license-manager license-server $RSP_LICENSE_SERVER
-elif test -f "$RSTUDIO_LICENSE_FILE_PATH"; then
-    /usr/lib/rstudio-server/bin/license-manager activate-file $RSTUDIO_LICENSE_FILE_PATH
+elif test -f "$RSW_LICENSE_FILE_PATH"; then
+    /usr/lib/rstudio-server/bin/license-manager activate-file $RSW_LICENSE_FILE_PATH
 fi
 
 # lest this be inherited by child processes


### PR DESCRIPTION
Adds a common license file path `/etc/rstudio-license/license.lic` for all products. Support fallback to old path.