### PR TITLE
Support RSP_ or RSW_ Prefixes for licensing

### DIFF
--- a/server-pro/startup.sh
+++ b/server-pro/startup.sh
@@ -44,6 +44,10 @@ mkdir -p /var/lib/rstudio-launcher/Kubernetes
 chown rstudio-server:rstudio-server /var/lib/rstudio-launcher/Kubernetes
 su rstudio-server -c 'touch /var/lib/rstudio-launcher/Kubernetes/rstudio-kubernetes-launcher.log'
 
+# Support RSP_ or RSW_ prefix
+RSP_LICENSE=${RSP_LICENSE:-${RSW_LICENSE}}
+RSP_LICENSE_SERVER=${RSP_LICENSE_SERVER:-${RSW_LICENSE_SERVER}}
+
 # Activate License
 RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}
 if ! [ -z "$RSP_LICENSE" ]; then
@@ -57,6 +61,8 @@ fi
 # lest this be inherited by child processes
 unset RSP_LICENSE
 unset RSP_LICENSE_SERVER
+unset RSW_LICENSE
+unset RSW_LICENSE_SERVER
 
 # Create one user
 if [ $(getent passwd $RSP_TESTUSER_UID) ] ; then


### PR DESCRIPTION
We recently added the var `RSW_LICENSE_FILE_PATH`, but the existing licensing env vars are prefixed with `RSP_`. This updates the startup script to support `RSW_` as an alternate prefix to improve support for our helm work.