### PR TITLE
rename adhoc build to adhoc

### DIFF
--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -10,9 +10,8 @@ on:
         required: false
         default: "auto"
 
-name: build/test/push (preview)
+name: build/test/push (adhoc preview)
 jobs:
-
 
   matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
should make it easier to differentiate in the UI, hopefully