### PR TITLE
Tweak execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,11 @@ test-server-pro-i:
 
 run-rsp: run-server-pro
 run-server-pro:  ## Run RSP container
-	docker rm rstudio-server-pro
+	docker rm -f rstudio-server-pro
 	docker run -it --privileged \
 		--name rstudio-server-pro \
 		-p 8787:8787 \
+		-v $(PWD)/server-pro/conf:/etc/rstudio/ \
 		-v /run \
 		-e RSP_LICENSE=$(RSP_LICENSE) \
 		rstudio/rstudio-server-pro:$(RSP_VERSION) $(CMD)
@@ -106,7 +107,7 @@ test-connect-i:
 
 run-rsc: run-connect
 run-connect:  ## Run RSC container
-	docker rm rstudio-connect
+	docker rm -f rstudio-connect
 	docker run -it --privileged \
 		--name rstudio-connect \
 		-p 3939:3939 \
@@ -131,7 +132,7 @@ test-package-manager-i:
 
 run-rspm: run-package-manager
 run-package-manager:  ## Run RSPM container
-	docker rm rstudio-package-manager
+	docker rm -f rstudio-package-manager
 	docker run -it --privileged \
 		--name rstudio-package-manager \
 		-p 4242:4242 \

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends \
         libuser1-dev \
         libxext6 \
         libxrender1 \
+	oddjob-mkhomedir \
         openssh-client \
         rrdtool \
         sssd \

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -27,11 +27,11 @@ RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends \
         libuser1-dev \
         libxext6 \
         libxrender1 \
-	    oddjob-mkhomedir \
+        oddjob-mkhomedir \
         openssh-client \
         rrdtool \
         sssd \
-	    sudo \
+        sudo \
         supervisor \
         wget \
     && apt-get clean \

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -139,6 +139,7 @@ RUN rstudio-server install-vs-code /opt/code-server/
 
 # Copy config
 COPY conf/* /etc/rstudio/
+COPY pam/* /etc/pam.d/
 
 # Add LimLM certs
 COPY *.crt /var/tmp/

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -153,5 +153,5 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log && \
 EXPOSE 8787/tcp
 EXPOSE 5559/tcp
 
-ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
-CMD []
+ENTRYPOINT []
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends \
         git \
         libcap2 \
         libglib2.0-0 \
+        libpam-sss \
         libpq5 \
         libsm6 \
         libssl1.0.0 \
@@ -26,11 +27,11 @@ RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends \
         libuser1-dev \
         libxext6 \
         libxrender1 \
-	oddjob-mkhomedir \
+	    oddjob-mkhomedir \
         openssh-client \
         rrdtool \
         sssd \
-	sudo \
+	    sudo \
         supervisor \
         wget \
     && apt-get clean \

--- a/server-pro/Dockerfile
+++ b/server-pro/Dockerfile
@@ -140,7 +140,6 @@ RUN rstudio-server install-vs-code /opt/code-server/
 
 # Copy config
 COPY conf/* /etc/rstudio/
-COPY pam/* /etc/pam.d/
 
 # Add LimLM certs
 COPY *.crt /var/tmp/
@@ -150,7 +149,8 @@ RUN cp -v /var/tmp/*.crt /usr/local/share/ca-certificates/ && \
 # Create log dir
 RUN mkdir -p /var/lib/rstudio-server/monitor/log && \
     chown -R rstudio-server:rstudio-server /var/lib/rstudio-server/monitor && \
-    mkdir -p /startup/custom/
+    mkdir -p /startup/custom/ && \
+    echo 'session required pam_mkhomedir.so skel=/etc/skel umask=0022' >> /etc/pam.d/common-session
 
 EXPOSE 8787/tcp
 EXPOSE 5559/tcp

--- a/server-pro/pam/rstudio
+++ b/server-pro/pam/rstudio
@@ -1,0 +1,14 @@
+#%PAM-1.0
+auth sufficient pam_sss.so forward_pass
+auth required pam_unix.so try_first_pass nullok
+auth optional pam_permit.so
+auth required pam_env.so
+
+account [default=bad success=ok user_unknown=ignore authinfo_unavail=ignore] pam_sss.so
+account required pam_unix.so
+account optional pam_permit.so
+account required pam_time.so
+
+password sufficient pam_sss.so use_authtok
+password required pam_unix.so try_first_pass nullok sha512 shadow
+password optional pam_permit.so

--- a/server-pro/pam/rstudio-session
+++ b/server-pro/pam/rstudio-session
@@ -1,0 +1,26 @@
+#%PAM-1.0
+
+# This allows root to su without passwords (this is required)
+# DO NOT use in the "rstudio" profile
+auth sufficient pam_rootok.so
+auth sufficient pam_sss.so forward_pass
+auth required pam_unix.so try_first_pass nullok
+auth optional pam_permit.so
+auth required pam_env.so
+
+account [default=bad success=ok user_unknown=ignore authinfo_unavail=ignore] pam_sss.so
+account required pam_unix.so
+account optional pam_permit.so
+account required pam_time.so
+
+password sufficient pam_sss.so use_authtok
+password required pam_unix.so try_first_pass nullok sha512 shadow
+password optional pam_permit.so
+
+session required pam_mkhomedir.so skel=/etc/skel umask=0022
+session required pam_env.so readenv=1
+session required pam_env.so readenv=1 envfile=/etc/default/locale
+session required pam_limits.so
+session required pam_unix.so
+session optional pam_sss.so
+session optional pam_permit.so


### PR DESCRIPTION
add pam config
  - presuming that users will need to overwrite the whole pam directory (or the rstudio / rstudio-session profiles) if they want to change this
  - will allow sssd auth out of the box