### PR TITLE
Fix for url / encoding

### DIFF
--- a/workbench/Dockerfile
+++ b/workbench/Dockerfile
@@ -123,7 +123,7 @@ RUN chmod +x /usr/local/bin/startup.sh
 
 # Install RStudio Workbench --------------------------------------------------#
 ARG RSW_VERSION=2021.09.0+351.pro6
-ARG RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/bionic/amd64
+ARG RSW_DOWNLOAD_URL=https://download2.rstudio.org/server/bionic/amd64
 ARG RSW_NAME=rstudio-workbench
 RUN apt-get update --fix-missing \
     && RSW_VERSION_URL=`echo -n "${RSW_VERSION}" | sed 's/+/%2b/g'` \

--- a/workbench/Dockerfile
+++ b/workbench/Dockerfile
@@ -123,10 +123,10 @@ RUN chmod +x /usr/local/bin/startup.sh
 
 # Install RStudio Workbench --------------------------------------------------#
 ARG RSW_VERSION=2021.09.0+351.pro6
-ARG RSW_DOWNLOAD_URL=https://download2.rstudio.org/server/bionic/amd64
+ARG RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/bionic/amd64
 ARG RSW_NAME=rstudio-workbench
 RUN apt-get update --fix-missing \
-    && RSW_VERSION_URL=`echo -n "${RSW_VERSION}" | sed 's/+/-/g'` \
+    && RSW_VERSION_URL=`echo -n "${RSW_VERSION}" | sed 's/+/%2b/g'` \
     && curl -o rstudio-workbench.deb ${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb \
     && gdebi --non-interactive rstudio-workbench.deb \
     && rm rstudio-workbench.deb \


### PR DESCRIPTION
Build system does not yet encode + with a -, instead have to %2b
Switched to rstudio-ide-builds bucket to support dailies as well as
released