### PR TITLE
Bring Connect and Content images into parity with common sys-dependencies installed by setup-assistant 

### DIFF
--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update --fix-missing \
     && apt-get install -y --no-install-recommends \
         bzip2 \
         ca-certificates \
-        default-jdk \
         gdal-bin \
         gdebi-core \
         git \

--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -12,17 +12,54 @@ ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3008,DL3009
 RUN apt-get update --fix-missing \
     && apt-get install -y --no-install-recommends \
-        wget \
         bzip2 \
         ca-certificates \
-        libglib2.0-0 \
-        libxext6 \
-        libsm6 \
-        libxrender1 \
+        default-jdk \
+        gdal-bin \
         gdebi-core \
+        git \
+        gsfonts \
+        imagemagick \
+        libcairo2-dev \
+        libcurl4-openssl-dev \
+        libfontconfig1-dev \
+        libfreetype6-dev \
+        libfribidi-dev \
+        libgdal-dev \
+        libgeos-dev \
+        libgl1-mesa-dev \
+        libglib2.0-0 \
+        libglpk-dev \
+        libglu1-mesa-dev \
+        libgmp3-dev \
+        libharfbuzz-dev \
+        libicu-dev \
+        libjpeg-dev \
+        libmagick++-dev \
+        libmysqlclient-dev \
+        libpng-dev \
+        libproj-dev \
+        libsm6 \
+        libsodium-dev \
+        libssh2-1-dev \
+        libssl-dev \
         libssl1.0.0 \
-        libssl-dev git \
-	sudo \
+        libtiff-dev \
+        libudunits2-dev \
+        libv8-dev \
+        libxext6 \
+        libxml2-dev \
+        libxrender1 \
+        make \
+        perl \
+	    sudo \
+        tcl \
+        tk \
+        tk-dev \
+        tk-table \
+        unixodbc-dev \
+        wget \
+        zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update --fix-missing \
         libxrender1 \
         make \
         perl \
-	    sudo \
+        sudo \
         tcl \
         tk \
         tk-dev \

--- a/content/base/bionic/Dockerfile
+++ b/content/base/bionic/Dockerfile
@@ -27,6 +27,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         default-jdk \
         gdal-bin \
         git \
+        gsfonts \
         imagemagick \
         libcairo2-dev \
         libcurl4-openssl-dev \
@@ -53,6 +54,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libtiff-dev \
         libudunits2-dev \
         libv8-dev \
+        libicu-dev \
         libxml2-dev \
         make \
         perl \


### PR DESCRIPTION
Connect Setup Assistant (as well as the manual instructions) provide a list of common system dependencies required by the "common" list of R packages (top 80%). This list (as found / maintained in `https://github.com/rstudio/connect-setup/blob/main/scripts/sysrec/r-pkgs`) is used to query RSPM to determine a list of system dependencies to install.

I have taken the generated list of system dependencies for Ubuntu 18.04, and added any missing ones to the docker files driving the connect image and the content base image.

The connect image was pretty bare. With the changes, the image size has increased from 2.94GB to 3.97GB.

The content base image was fairly complete and was only missing a few dependencies. The size in GB did not appear to change for these image sizes.

closes rstudio/connect#20122

