### PR TITLE
add libgit2 sysdep

### DIFF
--- a/content/base/bionic/Dockerfile
+++ b/content/base/bionic/Dockerfile
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         libfribidi-dev \
         libgdal-dev \
         libgeos-dev \
+        libgit2-dev \
         libgl1-mesa-dev \
         libglpk-dev \
         libglu1-mesa-dev \


### PR DESCRIPTION
this is important to the `gert` package, which is increasingly used in
the `tidyverse`