### PR TITLE
delete pro-drivers rpm and deb after installation 

### DIFF
--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update -y && \
 
 ARG RSW_VERSION=2021.09.1+372.pro1
 ARG RSW_NAME=rstudio-workbench
-ARG RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/bionic/amd64
+ARG RSW_DOWNLOAD_URL=https://download2.rstudio.org/server/bionic/amd64
 RUN apt-get update --fix-missing \
     && apt-get install -y gdebi-core \
     && RSW_VERSION_URL=`echo -n "${RSW_VERSION}" | sed 's/+/-/g'` \
@@ -110,6 +110,21 @@ RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packag
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y locales && \
     rm -rf /var/lib/apt/lists/*
+
+# Install Java ----------------------------------------------------------------#
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+	default-jdk && \
+	rm -rf /var/lib/apt/lists/*
+
+# Reconfigure R  
+RUN /opt/R/${R_VERSION}/bin/R CMD javareconf 
+
+# Add ldpaths to rstudio config
+RUN mkdir -p /etc/rstudio && echo "Path: /opt/R/${R_VERSION}\nScript: /opt/R/${R_VERSION}/lib/R/etc/ldpaths" > /etc/rstudio/r-versions
+
+RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("rJava", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -126,6 +126,19 @@ RUN mkdir -p /etc/rstudio && echo "Path: /opt/R/${R_VERSION}\nScript: /opt/R/${R
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("rJava", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'
 
+# Add pointer to latest CRAN and bioconductor repositories (binary) from public package manager
+COPY create.R /
+RUN /opt/R/${R_VERSION}/bin/Rscript /create.R  > /opt/R/${R_VERSION}/lib/R/etc/Rprofile.site && rm -f /create.R
+
+# Add renv settings for global cache as well as linux distro specific directory hierarchy in cache
+RUN echo "#renv settings\nRENV_PATHS_PREFIX_AUTO = TRUE\nRENV_PATHS_CACHE=/scratch/renv" >> /opt/R/${R_VERSION}/lib/R/etc/Renviron.site
+
+# Disable local package installs 
+RUN echo "#Disable local package installs into R_LIBS_USER\nR_LIBS_USER=/dev/null\n" >> /opt/R/${R_VERSION}/lib/R/etc/Renviron.site
+
+# Install renv 
+RUN /opt/R/${R_VERSION}/bin/R -q -e "install.packages('renv',lib='/opt/R/${R_VERSION}/lib/R/library/')" 
+
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -139,6 +139,14 @@ RUN echo "#Disable local package installs into R_LIBS_USER\nR_LIBS_USER=/dev/nul
 # Install renv 
 RUN /opt/R/${R_VERSION}/bin/R -q -e "install.packages('renv',lib='/opt/R/${R_VERSION}/lib/R/library/')" 
 
+# Install zeromq
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        libzmq5 && \
+        rm -rf /var/lib/apt/lists/*
+
+
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -100,6 +100,7 @@ RUN curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers_${DRI
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive gdebi --non-interactive rstudio-drivers_${DRIVERS_VERSION}_amd64.deb && \
     rm -rf /var/lib/apt/lists/* && \
+    rm -f rstudio-drivers_${DRIVERS_VERSION}_amd64.deb && \
     cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'

--- a/r-session-complete/bionic/build.sh
+++ b/r-session-complete/bionic/build.sh
@@ -1,0 +1,12 @@
+VERSION=0.2
+docker build -f Dockerfile . -t r-session-complete:${VERSION}-bionic
+docker run -d -p 5000:5000 --restart=always --name registry registry:2
+docker tag r-session-complete:${VERSION}-bionic localhost:5000/r-session-complete:${VERSION}-bionic 
+docker push localhost:5000/r-session-complete:${VERSION}-bionic 
+export TMP=/efs/tmp
+export TEMP=$TMP
+export TMPDIR=$TMP
+export TEMPDIR=$TMP
+export SINGULARITY_NOHTTPS=1
+/efs/singularity/3.8.5/bin/singularity build /efs/singularity/containers/r-session-complete.img test.sdef 
+

--- a/r-session-complete/bionic/build.sh
+++ b/r-session-complete/bionic/build.sh
@@ -1,9 +1,9 @@
-VERSION=0.2
+VERSION=0.4
 docker build -f Dockerfile . -t r-session-complete:${VERSION}-bionic
 docker run -d -p 5000:5000 --restart=always --name registry registry:2
 docker tag r-session-complete:${VERSION}-bionic localhost:5000/r-session-complete:${VERSION}-bionic 
 docker push localhost:5000/r-session-complete:${VERSION}-bionic 
-export TMP=/efs/tmp
+export TMP=/scratch/tmp
 export TEMP=$TMP
 export TMPDIR=$TMP
 export TEMPDIR=$TMP

--- a/r-session-complete/bionic/create.R
+++ b/r-session-complete/bionic/create.R
@@ -1,0 +1,51 @@
+# Needs to be run as an admin that has write permissions to /etc/rstudio
+#
+# This script when run against any R version will 
+# * figure out which compatible BioConductor Version exist
+# * get all the URLs for the repositories of BioConductor
+# * output a Rprofile.site to stdout  
+
+# OS flag for binaries (leave empty if not needed
+
+binaryflag<-""
+
+if(file.exists("/etc/debian_version")) {
+    binaryflag <- "__linux__/focal"
+}
+
+if(file.exists("/etc/redhat-release")) {
+    binaryflag <- "__linux__/centos7"
+}
+
+# Check if BiocManager is installed - needed to determine BioConductor Version
+if ( ! "BiocManager" %in% utils::installed.packages() ) {
+    Sys.setenv(R_PROFILE_USER = "/dev/null")
+    system(paste("mkdir -p", Sys.getenv("R_LIBS_USER")))
+    suppressMessages(utils::install.packages("BiocManager",quiet=TRUE,repos="https://cran.r-project.org/", lib=Sys.getenv("R_LIBS_USER")))
+    Sys.unsetenv("R_PROFILE_USER")
+  }
+suppressMessages(library(BiocManager, lib.loc=Sys.getenv("R_LIBS_USER"),quietly=TRUE,verbose=FALSE))
+# Get current repo settings
+r <- getOption("repos")
+
+# Package Manager URL
+pm <- "https://packagemanager.rstudio.com"
+
+# Version of BioConductor as given by BiocManager (can also be manually set)
+suppressMessages(biocvers <- BiocManager::version())
+
+# Bioconductor Repositories
+suppressMessages(r<-gsub("https://bioconductor.org", paste0(pm,"/bioconductor/",binaryflag), BiocManager::repositories(version=biocvers)))
+
+# CRAN repo
+r["CRAN"] <- paste0(pm,"/cran/",binaryflag,"/latest/")
+
+nr=length(r)
+r<-c(r[nr],r[1:nr-1])
+
+
+cat("local({\n")
+cat('  r <- getOption("repos")\n')
+ctr=0;for (i in names(r)) {ctr<-ctr+1;cat(paste0('  r["',i,'"]="',r[ctr],'"\n'))}
+cat("  options(repos = r)\n")
+cat("})\n")

--- a/r-session-complete/bionic/test.sdef
+++ b/r-session-complete/bionic/test.sdef
@@ -1,3 +1,14 @@
 Bootstrap: docker
-From: r-session-complete:0.2-bionic 
+From: r-session-complete:0.4-bionic 
 Registry: localhost:5000
+
+%post
+    # SLURM stuff
+    groupadd -g 401 slurm 
+    useradd -u 401 -g 401 slurm  
+    apt-get install libmunge2
+
+    rm -rf /var/cache/apt/*
+
+%environment
+    export PATH=/opt/slurm/bin:$PATH

--- a/r-session-complete/bionic/test.sdef
+++ b/r-session-complete/bionic/test.sdef
@@ -1,0 +1,3 @@
+Bootstrap: docker
+From: r-session-complete:0.2-bionic 
+Registry: localhost:5000

--- a/r-session-complete/bionic/test.sdef
+++ b/r-session-complete/bionic/test.sdef
@@ -6,9 +6,7 @@ Registry: localhost:5000
     # SLURM stuff
     groupadd -g 401 slurm 
     useradd -u 401 -g 401 slurm  
-    apt-get install libmunge2
-
-    rm -rf /var/cache/apt/*
+    apt-get update && apt-get install libmunge2 && rm -rf /var/cache/apt/*
 
 %environment
     export PATH=/opt/slurm/bin:$PATH

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -97,6 +97,7 @@ RUN yum update -y && \
 RUN curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers-${DRIVERS_VERSION}.el7.x86_64.rpm && \
     yum install -y rstudio-drivers-${DRIVERS_VERSION}.el7.x86_64.rpm && \
     yum clean all && \
+    rm -f rstudio-drivers-${DRIVERS_VERSION}.el7.x86_64.rpm && \
     cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/centos7/latest")'

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -115,6 +115,13 @@ RUN mkdir -p /etc/rstudio && echo "Path: /opt/R/${R_VERSION}\nScript: /opt/R/${R
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("rJava", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'
 
+    /opt/R/${R_VERSION}/bin/Rscript /create.R  > /opt/R/${R_VERSION}/lib/R/etc/Rprofile.site && \
+    echo "#renv settings\nRENV_PATHS_PREFIX_AUTO = TRUE\nRENV_PATHS_CACHE=/scratch/renv" >> /opt/R/${R_VERSION}/lib/R/etc/Renviron.si
+te && \
+    echo "#Disable local package installs into R_LIBS_USER\nR_LIBS_USER=/dev/null\n" >> /opt/R/${R_VERSION}/lib/R/etc/Renviron.si
+te && \
+    /opt/R/${R_VERSION}/bin/R -q -e "install.packages('renv',lib='/opt/R/${R_VERSION}/lib/R/library/')" && \
+
 # Locale configuration --------------------------------------------------------#
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -21,8 +21,9 @@ RUN yum update -y && \
 
 ARG RSW_VERSION=2021.09.1+372.pro1
 ARG RSW_NAME=rstudio-workbench-rhel
-ARG RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/centos7/x86_64
+ARG RSW_DOWNLOAD_URL=https://download2.rstudio.org/server/centos7/x86_64
 RUN RSW_VERSION_URL=`echo -n "${RSW_VERSION}" | sed 's/+/-/g'` \
+    && echo ${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-x86_64.rpm \
     && curl -o rstudio-workbench.rpm ${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-x86_64.rpm \
     && yum install -y rstudio-workbench.rpm \
     && rm rstudio-workbench.rpm \
@@ -101,6 +102,18 @@ RUN curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers-${DRI
     cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/centos7/latest")'
+
+# Install Java ----------------------------------------------------------------#
+
+RUN yum install java-1.8.0-openjdk-devel -y && \
+	yum clean all
+# Reconfigure R
+RUN /opt/R/${R_VERSION}/bin/R CMD javareconf
+
+# Add ldpaths to rstudio config
+RUN mkdir -p /etc/rstudio && echo "Path: /opt/R/${R_VERSION}\nScript: /opt/R/${R_VERSION}/lib/R/etc/ldpaths" > /etc/rstudio/r-versions
+
+RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("rJava", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'
 
 # Locale configuration --------------------------------------------------------#
 

--- a/workbench/Dockerfile
+++ b/workbench/Dockerfile
@@ -139,6 +139,26 @@ RUN apt-get update --fix-missing \
 
 RUN rstudio-server install-vs-code /opt/code-server/
 
+# Install Java ----------------------------------------------------------------#
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        default-jdk && \
+        rm -rf /var/lib/apt/lists/*
+
+# Reconfigure R
+RUN R CMD javareconf
+RUN /opt/R/${R_VERSION_ALT}/bin/R CMD javareconf
+
+# Add ldpaths to rstudio config
+RUN mkdir -p /etc/rstudio && echo "Path: /opt/R/${R_VERSION}\nScript: /opt/R/${R_VERSION}/lib/R/etc/ldpaths" > /etc/rstudio/r-versions
+
+RUN /opt/R/${R_VERSION_ALT}/bin/R -e 'install.packages("rJava", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'
+RUN R -e 'install.packages("rJava", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'
+
+# Add ldpaths to rstudio config
+RUN mkdir -p /etc/rstudio && echo "Path: /opt/R/${R_VERSION_ALT}\nLabel: R ${R_VERSION_ALT}\nScript: /opt/R/${R_VERSION_ALT}/lib/R/etc/ldpaths" > /etc/rstudio/r-versions
+RUN echo "\n\nPath: /usr/lib/R\nLabel: R 3.6.3\nScript: /usr/lib/R/etc/ldpaths" >> /etc/rstudio/r-versions
 # Copy config
 COPY conf/* /etc/rstudio/
 COPY sssd.conf /etc/sssd/sssd.conf


### PR DESCRIPTION
in order to keep docker container size under control.

It seems we are leaving the pro-drivers install packages lying around in the container - since I am not aware this would be any useful I am suggesting to remove them. 