### PR TITLE
delete rstudio-drivers deb and rpm from r-session-complete after install

### DIFF
--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -100,6 +100,7 @@ RUN curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers_${DRI
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive gdebi --non-interactive rstudio-drivers_${DRIVERS_VERSION}_amd64.deb && \
     rm -rf /var/lib/apt/lists/* && \
+    rm -f rstudio-drivers_${DRIVERS_VERSION}_amd64.deb && \
     cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -97,6 +97,7 @@ RUN yum update -y && \
 RUN curl -O https://drivers.rstudio.org/7C152C12/installer/rstudio-drivers-${DRIVERS_VERSION}.el7.x86_64.rpm && \
     yum install -y rstudio-drivers-${DRIVERS_VERSION}.el7.x86_64.rpm && \
     yum clean all && \
+    rm -f rstudio-drivers-${DRIVERS_VERSION}.el7.x86_64.rpm && \
     cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/centos7/latest")'


### PR DESCRIPTION
We are installing our pro-drivers in r-session-complete but do not seem to remove the deb and rpm package once installed. Will save a few hundred of MB of storage space in the docker container. 