### PR TITLE
fix "latest" reference to point at prairie-trillium

### DIFF
--- a/get-version.py
+++ b/get-version.py
@@ -84,8 +84,8 @@ def clean_product_selection(product: str) -> str:
 
 
 def rstudio_workbench_daily():
-    version_json = download_json("https://dailies.rstudio.com/rstudio/latest/index.json")
-    return version_json['products']['workbench']['platforms']['bionic']['version']
+    version_json = download_json("https://dailies.rstudio.com/rstudio/prairie-trillium/index.json")
+    return version_json['workbench']['platforms']['bionic']['version']
 
 
 def download_json(url):


### PR DESCRIPTION
it looks like index.json has also modified its data structure,
so we change how we index the keys

```
✗ ./get-version.py workbench --type daily
Providing version for product: 'workbench' and version type: 'daily'
Got daily version: '2022.02.0-daily+361.pro1'
2022.02.0-daily+361.pro1
```