### PR TITLE
Remove conda-forge channel from the Connect base docker image

### DIFF
--- a/content/base/bionic/Dockerfile
+++ b/content/base/bionic/Dockerfile
@@ -116,7 +116,7 @@ ARG PYTHON_VERSION=3.7.6
 RUN curl -fsSL -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh \
     && chmod 755 miniconda.sh \
     && ./miniconda.sh -b -p /opt/miniconda \
-    && /opt/miniconda/bin/conda create --quiet --yes --prefix /opt/python/${PYTHON_VERSION} --channel conda-forge python=${PYTHON_VERSION} virtualenv \
+    && /opt/miniconda/bin/conda create --quiet --yes --prefix /opt/python/${PYTHON_VERSION} python=${PYTHON_VERSION} virtualenv \
     && rm -f miniconda.sh \
     # remove miniconda too, for size
     && rm -rf /opt/miniconda


### PR DESCRIPTION
### Problem

A recent rebuild of the docker images has exposed an error in which content deployed to the Python 3.6 images fails with an error similar to:
```
2022/01/10 21:30:06.529560800 Creating environment: -sH_hhdsr0sWumncv8Jm7w
2022/01/10 21:30:06.611341300 Traceback (most recent call last):
2022/01/10 21:30:06.611365000   File "/opt/python/3.6.13/lib/python3.6/runpy.py", line 183, in _run_module_as_main
2022/01/10 21:30:06.616058100     mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
2022/01/10 21:30:06.617148200   File "/opt/python/3.6.13/lib/python3.6/runpy.py", line 142, in _get_module_details
2022/01/10 21:30:06.617873600     return _get_module_details(pkg_main_name, error)
2022/01/10 21:30:06.618644200   File "/opt/python/3.6.13/lib/python3.6/runpy.py", line 109, in _get_module_details
2022/01/10 21:30:06.619857600     __import__(pkg_name)
2022/01/10 21:30:06.620486500   File "/opt/python/3.6.13/lib/python3.6/site-packages/virtualenv/__init__.py", line 3, in <module>
2022/01/10 21:30:06.621421900     from .run import cli_run, session_via_cli
2022/01/10 21:30:06.622110400   File "/opt/python/3.6.13/lib/python3.6/site-packages/virtualenv/run/__init__.py", line 7, in <module>
2022/01/10 21:30:06.623030200     from ..app_data import make_app_data
2022/01/10 21:30:06.623928100   File "/opt/python/3.6.13/lib/python3.6/site-packages/virtualenv/app_data/__init__.py", line 12, in <module>
2022/01/10 21:30:06.625106100     from .read_only import ReadOnlyAppData
2022/01/10 21:30:06.626683000   File "/opt/python/3.6.13/lib/python3.6/site-packages/virtualenv/app_data/read_only.py", line 3, in <module>
2022/01/10 21:30:06.628511000     from virtualenv.util.lock import NoOpFileLock
2022/01/10 21:30:06.628920900   File "/opt/python/3.6.13/lib/python3.6/site-packages/virtualenv/util/lock.py", line 10, in <module>
2022/01/10 21:30:06.630144100 virtualenv failed with exit code 1
2022/01/10 21:30:06.629749000     from filelock import FileLock, Timeout
2022/01/10 21:30:06.630685300   File "/opt/python/3.6.13/lib/python3.6/site-packages/filelock/__init__.py", line 8
2022/01/10 21:30:06.632201900     from __future__ import annotations
2022/01/10 21:30:06.633694500     ^
2022/01/10 21:30:06.634785300 SyntaxError: future feature annotations is not defined
```

It seems that the filelock package put out a new release about 2 weeks ago that drops Python 3.5 and 3.6 support. The metadata for that release specifies python_requires = >=3.7, so it should never be installed on python 3.6. According to https://github.com/pypa/virtualenv/issues/2280, older versions of pip might not honor python_requires, allowing the incompatible version to be installed. However, in this case it looks like the Docker image build uses conda to install python and virtualenv, and the conda package (on conda-forge) also seems to be marked as requiring python 3.7.  So it's not clear why conda is choosing that package version, but it clearly is not compatible.

### Solution Approach

Stop specifying the conda-forge channel within the conda command, since the only packages being installed are python and virtualenv and both are part of the base anaconda channel.

### Verification Approach

1. Rebuilt the images using the `./build-images.sh build` command (within the `content` subdirectory). This command pushes image updates to the `docker.io/rstudio` repo.
2. Using the internal development tools for the RStudio Connect team, a test remote execution environment was updated to use the updated images.
3. A python dash app was updated to have Python 3.6.18 within its manifest.json file and deployed to the test environment's RStudio Connect server.

Deployment and access was successful.