### PR TITLE
change azure ml image version

### DIFF
--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -67,10 +67,10 @@ jobs:
           tags: |
             rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
             rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
-            rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}{{ steps.version.outputs.SHA_SHORT }}
+            rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}${{ steps.version.outputs.SHA_SHORT }}
             ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
             ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
-            ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}{{ steps.version.outputs.SHA_SHORT }}
+            ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}${{ steps.version.outputs.SHA_SHORT }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           load: true
@@ -122,5 +122,7 @@ jobs:
         run: |
           docker push rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
           docker push rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
+          docker push rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}${{ steps.version.outputs.SHA_SHORT }}
           docker push ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
           docker push ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
+          docker push ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}${{ steps.version.outputs.SHA_SHORT }}

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -67,8 +67,10 @@ jobs:
           tags: |
             rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
             rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
+            rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}{{ steps.version.outputs.SHA_SHORT }}
             ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
             ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
+            ghcr.io/rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}{{ steps.version.outputs.SHA_SHORT }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           load: true

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -38,6 +38,14 @@ jobs:
           # NOTE: --local ensures that "latest" builds use the version in our Makefile (instead of latest from the web)
           VERSION=`./get-version.py ${{ matrix.config.product }} --type=${{ matrix.config.version }} --local`
           SAFE_VERSION=`echo -n "$VERSION" | sed 's/+/-/g'`
+
+          # strip build metadata for azure builds
+          if [[ "true" == "${{ matrix.config.product == 'rstudio-workbench-for-microsoft-azure-ml' }}" ]]; then
+            SAFE_VERSION=`echo -n "$SAFE_VERSION" | sed 's/^\([0-9]\{4\}\.[0-9]\{2\}\.[0-9]*\).*/\1/g'`
+          fi
+
+          echo "::set-output name=SHA_SHORT::$(git rev-parse --short HEAD)"
+
           echo "::set-output name=VERSION::${VERSION}"
           echo "::set-output name=SAFE_VERSION::${SAFE_VERSION}"
 

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -40,11 +40,11 @@ jobs:
           SAFE_VERSION=`echo -n "$VERSION" | sed 's/+/-/g'`
 
           # strip build metadata for azure builds
-          if [[ "true" == "${{ matrix.config.product == 'rstudio-workbench-for-microsoft-azure-ml' }}" ]]; then
+          if [[ "${{ matrix.config.product  }}" == "rstudio-workbench-for-microsoft-azureml" ]]; then
             SAFE_VERSION=`echo -n "$SAFE_VERSION" | sed 's/^\([0-9]\{4\}\.[0-9]\{2\}\.[0-9]*\).*/\1/g'`
           fi
 
-          echo "::set-output name=SHA_SHORT::$(git rev-parse --short HEAD)"
+          echo "::set-output name=SHA_SHORT::--$(git rev-parse --short HEAD)"
 
           echo "::set-output name=VERSION::${VERSION}"
           echo "::set-output name=SAFE_VERSION::${SAFE_VERSION}"

--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -25,6 +25,7 @@ jobs:
           MATRIX=$(jq -Mcr < matrix-preview.json)
           echo "Raw Matrix: $MATRIX"
           echo "Input - which: ${{ github.event.inputs.which }}"
+          # NOTE: blank which input here means that every product is selected
           MATRIX_FILTER=$(echo "$MATRIX" | jq -Mcr 'map(select((.product | startswith("${{ github.event.inputs.which }}"))or("all"=="${{ github.event.inputs.which }}")))')
           echo "Filtered Matrix: $MATRIX_FILTER"
           echo "::set-output name=matrix::$MATRIX_FILTER"

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -24,6 +24,7 @@ jobs:
           MATRIX=$(jq -Mcr < matrix-preview.json)
           echo "Raw Matrix: $MATRIX"
           echo "Input - which: ${{ github.event.inputs.which }}"
+          # NOTE: blank which input here means that every product is selected
           MATRIX_FILTER=$(echo "$MATRIX" | jq -Mcr 'map(select((.product | startswith("${{ github.event.inputs.which }}"))or("all"=="${{ github.event.inputs.which }}")))')
           echo "Filtered Matrix: $MATRIX_FILTER"
           echo "::set-output name=matrix::$MATRIX_FILTER"

--- a/get-version.py
+++ b/get-version.py
@@ -62,15 +62,15 @@ def clean_product_selection(product: str) -> str:
 
     rsw = re.compile('^rsw$')
     if rsw.match(product):
-      product = 'workbench'
+        product = 'workbench'
 
     rsc = re.compile('^rsc$')
     if rsc.match(product):
-      product = 'connect'
+        product = 'connect'
 
     rspm = re.compile('^rspm$')
     if rspm.match(product):
-      product = 'package-manager'
+        product = 'package-manager'
 
     session_pref = re.compile('^r-session')
     if session_pref.match(product):
@@ -183,7 +183,7 @@ if __name__ == "__main__":
         default=["release"]
     )
     parser.add_argument(
-        "--local","-l",
+        "--local", "-l",
         action="store_true",
         help="Whether to use the 'local' version for 'release'. Parsed from the local Makefile",
     )
@@ -220,6 +220,9 @@ if __name__ == "__main__":
         exit(1)
 
     print(f"Providing version for product: '{selected_product}' and version type: '{version_type}'", file=sys.stderr)
+
+    # set a default value - this should never make it all the way through
+    version = 'UNDEFINED'
 
     # ------------------------------------------
     # Use override, if defined

--- a/get-version.py
+++ b/get-version.py
@@ -15,6 +15,7 @@
 #   - rstudio- prefix is removed
 #   - -preview suffix is removed
 #   - r-session prefixed products are replaced with workbench
+#   - workbench prefixed products are replaced with workbench
 #   - connect- prefixed products are replaced with connect
 #   - version latest == release
 
@@ -45,6 +46,7 @@ def clean_product_selection(product: str) -> str:
     - Remove rstudio- prefix
     - Remove -preview suffix
     - Convert r-session prefixed products to workbench
+    - Convert workbench prefixed products to workbench
     - Convert connect- prefixed products to connect
     - Convert rsw -> workbench, rsc -> connect, rspm -> package-manager
 

--- a/helper/workbench-for-microsoft-azureml/Dockerfile
+++ b/helper/workbench-for-microsoft-azureml/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends \
         ca-certificates \
         gdebi-core \
         git \
-	    g++ \
+        g++ \
         libcap2 \
         libglib2.0-0 \
         libpq5 \

--- a/helper/workbench-for-microsoft-azureml/Dockerfile
+++ b/helper/workbench-for-microsoft-azureml/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends \
         ca-certificates \
         gdebi-core \
         git \
-	g++ \
+	    g++ \
         libcap2 \
         libglib2.0-0 \
         libpq5 \

--- a/helper/workbench-for-microsoft-azureml/install-r.sh
+++ b/helper/workbench-for-microsoft-azureml/install-r.sh
@@ -3,7 +3,7 @@ set -xe -o pipefail
 
 # quick way to call out specific logging lines in packer stdout
 pp() {
-  printf "============== $1  ==============\n"
+  printf "============== %s ==============\n" "$1"
 }
 
 install_r_packages() {
@@ -23,7 +23,7 @@ install_r_packages() {
   local CRAN_REPO=${3:-"https://packagemanager.rstudio.com/cran/__linux__/${UBUNTU_CODENAME}/latest"}
 
   # create an R matrix-style string of packages
-  local r_packages=`awk '{print "\"" $0 "\""}' $1 | paste -d',' -s  -`
+  local r_packages=$(awk '{print "\"" $0 "\""}' "$1" | paste -d',' -s  -)
 
   # install packages enumerated in the file to the R binary passed
   pp "Installing R packages for $R_BIN"
@@ -35,7 +35,7 @@ for rvers in 3.3.3 3.4.4 3.5.3 3.6.3 4.0.5 4.1.2; do
     # install r version
     curl -O https://cdn.rstudio.com/r/ubuntu-1804/pkgs/r-${rvers}_1_amd64.deb
     DEBIAN_FRONTEND=noninteractive gdebi --non-interactive r-${rvers}_1_amd64.deb
-    rm -f ./r-${R_VERSION_ALT}_1_amd64.deb
+    rm -f ./r-${rvers}_1_amd64.deb
 
     # install packages
     install_r_packages /tmp/package-list.txt /opt/R/${rvers}/bin/R https://packagemanager.rstudio.com/cran/__linux__/bionic/latest


### PR DESCRIPTION
- strip the build metadata off of SAFE_VERSION
- create a reference variable for `SHA_SHORT`
- start building `SHA_SHORT` tags for all images


For example:
- `rstudio-workbench` image w/ RSW version `2021.09.2-382.pro1`:
    - `latest`
    - `2021.09.2-382.pro1`
    - `2021.09.2-382.pro1--abcd123`
- `rstudio-connect` image w/ RSC version `2021.12.1`:
    - `latest`
    - `2021.12.1`
    - `2021.12.1--abcd123`
- `rstudio-workbench-for-microsoft-azureml` image w/ RSW version `2021.09.2-382.pro1`:
    - `latest`
    - `2021.09.2`
    - `2021.09.2--abcd123`