### PR TITLE
RSC: write RSC logs to file by default

### DIFF
--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -5,6 +5,7 @@ set -x
 
 # Deactivate license when it exists
 deactivate() {
+    tail -n 200 /var/log/rstudio-connect.log
     echo "Deactivating license ..."
     /opt/rstudio-connect/bin/license-manager deactivate >/dev/null 2>&1
 }
@@ -25,4 +26,4 @@ unset RSC_LICENSE
 unset RSC_LICENSE_SERVER
 
 # Start RStudio Connect
-/opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg
+/opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg >>/var/log/rstudio-connect.log 2>&1


### PR DESCRIPTION
When the license deactivation trap is triggered, usually something went wrong during startup.
In some scenarios, for example when running on k8s, inspecting logs is not so easy as the pod is not accessible after a failed startup.

This proposed change 

1. Writes the logs to a file and allows users to make them persistent across container updates (for simple docker setups).
1. Allows to see what might have caused the startup failure by printing the tail of the logs before executing the license deactivation trap

(NB: This is our setup we use for quite some time. I have not yet found an advantage sending logs to stdout - but maybe there is? 🤔 )

Please see this PR as a proposal to be discussed and not as something that blocks us :)