### PR TITLE
identify and report Quarto installations

### DIFF
--- a/content/scripts/build-image-yaml.sh
+++ b/content/scripts/build-image-yaml.sh
@@ -58,6 +58,7 @@ for IMAGE in ${IMAGES} ; do
 
     R_FOUND=0
     PYTHON_FOUND=0
+    QUARTO_FOUND=0
 
     # examine-image.sh may produce duplicates; order and uniquify what we have.
     while IFS= read -r line; do
@@ -77,6 +78,12 @@ for IMAGE in ${IMAGES} ; do
             if [ ${R_FOUND} = 0 ] ; then
                 R_FOUND=1
                 echo "    r:"
+                echo "      installations:"
+            fi
+        elif [ "${language}" = "quarto" ] ; then
+            if [ ${QUARTO_FOUND} = 0 ] ; then
+                QUARTO_FOUND=1
+                echo "    quarto:"
                 echo "      installations:"
             fi
         fi


### PR DESCRIPTION
Slightly different than R and Python, as /opt/quarto could be either a
directory containing a single installation or a directory containing a number
of versioned installations.

Fixes #275

Given an image with a Quarto installation, which can be accomplished with the addition of the following to a Dockerfile:

```dockerfile
RUN curl -fsSL -O https://github.com/quarto-dev/quarto-cli/releases/download/v0.9.71/quarto-0.9.71-linux-amd64.deb && \
    export DEBIAN_FRONTEND=noninteractive && \
    apt-get update && \
    apt-get install -f -y ./quarto-0.9.71-linux-amd64.deb && \
    rm quarto-0.9.71-linux-amd64.deb && \
    rm -rf /var/lib/apt/lists/*
```

```bash
./content/scripts/build-image-yaml.sh IMAGE_NAME > image.yaml
# Analyzing: rstudio/connect:bionic
# ------------------------------------------------------------
# Found R at /opt/R/3.6.3/bin/R in /opt/R/3.6.3 with with canonical location /opt/R/3.6.3/bin/R and version 3.6.3.
# Found Python at /opt/python/3.8.12/bin/python in /opt/python/3.8.12 with canonical location /opt/python/3.8.12/bin/python3.8 and version 3.8.12.
# Found Quarto at /opt/quarto/bin/quarto in /opt/quarto with with canonical location /opt/quarto/bin/quarto and version 0.9.71.
```

The YAML produced:

```yaml
name: Kubernetes
images:
  -
    name: IMAGE_NAME
    python:
      installations:
        -
          path: /opt/python/3.8.12/bin/python3.8
          version: 3.8.12
    quarto:
      installations:
        -
          path: /opt/quarto/bin/quarto
          version: 0.9.71
    r:
      installations:
        -
          path: /opt/R/3.6.3/bin/R
          version: 3.6.3
```