### PR TITLE
add launcher.local.conf to support unprivileged mode

### DIFF
--- a/helper/workbench-for-microsoft-azure-ml/conf/launcher.local.conf
+++ b/helper/workbench-for-microsoft-azure-ml/conf/launcher.local.conf
@@ -1,0 +1,1 @@
+unprivileged=1


### PR DESCRIPTION
At present, local launcher is requiring privileged execution. This is bad 😄 We should relax it a bit