### PR TITLE
Remove unnecessary apt dependencies for Package Manager

### DIFF
--- a/package-manager/Dockerfile
+++ b/package-manager/Dockerfile
@@ -9,16 +9,6 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
-# hadolint ignore=DL3008,DL3009
-RUN apt-get update --fix-missing \
-    && apt-get install -y --no-install-recommends \
-        gdebi-core \
-        libssl1.0.0 \
-        libssl-dev \
-	sudo \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
 ENV PATH /opt/rstudio-pm/bin:$PATH
 
 # Runtime settings ------------------------------------------------------------#
@@ -36,9 +26,12 @@ EXPOSE 2112/tcp
 ARG RSPM_VERSION=2021.12.0-3
 ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu/amd64
 RUN apt-get update --fix-missing \
+    && apt-get install -y --no-install-recommends gdebi-core \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 gdebi -n rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \
+    && apt-get purge -y gdebi-core \
+    && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && ln -s /opt/rstudio-pm/bin/rspm /usr/local/bin/rspm

--- a/package-manager/NEWS.md
+++ b/package-manager/NEWS.md
@@ -1,3 +1,8 @@
+# 2022-04-06
+
+* Removed the `libssl-dev` and `gdebi-core` system dependencies from the final
+  image, since they are not runtime dependencies.
+
 # 1.2.2.1-17
 
 - Add NEWS.md


### PR DESCRIPTION
It seems that libssl and sudo are not actually required to install and run RSPM, so we can remove them. Further, gdebi-core is only used during installation, so we can install it temporarily during that step instead.

This has the following benefits:

* Fewer `RUN` steps, and fewer layers.

* Fewer system packages in the resulting image, making it 10M smaller.

* Improved build time, because we don't have two `apt`-related steps (and their attendant cache cleanup code).