### PR TITLE
Verify GPG signatures during Package Manager installation

### DIFF
--- a/package-manager/Dockerfile
+++ b/package-manager/Dockerfile
@@ -26,11 +26,13 @@ EXPOSE 2112/tcp
 ARG RSPM_VERSION=2021.12.0-3
 ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu/amd64
 RUN apt-get update --fix-missing \
-    && apt-get install -y --no-install-recommends gdebi-core \
+    && apt-get install -y --no-install-recommends gdebi-core dpkg-sig \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
+    && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
+    && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 gdebi -n rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \
-    && apt-get purge -y gdebi-core \
+    && apt-get purge -y gdebi-core dpkg-sig \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/package-manager/NEWS.md
+++ b/package-manager/NEWS.md
@@ -3,6 +3,8 @@
 * Removed the `libssl-dev` and `gdebi-core` system dependencies from the final
   image, since they are not runtime dependencies.
 
+* GPG signatures are now verified during Package Manager installation.
+
 # 1.2.2.1-17
 
 - Add NEWS.md


### PR DESCRIPTION
[RSPM signs its OS packages using GPG](https://docs.rstudio.com/rspm/2021.12.0/admin/getting-started/installation/#getting-started-validation). It seems like good supply chain security practice to verify them, so that's what this PR does.

Part of #286.