### PR TITLE
Avoid the COPY + chmod pattern

### DIFF
--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -96,8 +96,7 @@ ARG TINI_VERSION=0.18.0
 RUN curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini && \
     chmod +x /usr/local/bin/tini
 
-COPY startup.sh /usr/local/bin/startup.sh
-RUN chmod +x /usr/local/bin/startup.sh
+COPY --chmod=0775 startup.sh /usr/local/bin/startup.sh
 
 # Download RStudio Connect -----------------------------------------------------#
 ARG RSC_VERSION=2022.03.2

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,8 @@
+# 2022-04-07
+
+- The Dockerfile now uses BuildKit features and must be built with
+  DOCKER_BUILDKIT=1.
+
 # 2021.10.0
 
 - Add a bunch of system dependencies. This makes the image build bigger (~4GB),

--- a/package-manager/Dockerfile
+++ b/package-manager/Dockerfile
@@ -16,8 +16,7 @@ ARG TINI_VERSION=0.18.0
 RUN curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini && \
     chmod +x /usr/local/bin/tini
 
-COPY startup.sh /usr/local/bin/startup.sh
-RUN chmod +x /usr/local/bin/startup.sh
+COPY --chmod=0775 startup.sh /usr/local/bin/startup.sh
 
 EXPOSE 4242/tcp
 EXPOSE 2112/tcp

--- a/package-manager/NEWS.md
+++ b/package-manager/NEWS.md
@@ -1,3 +1,8 @@
+# 2022-04-07
+
+- The Dockerfile now uses BuildKit features and must be built with
+  DOCKER_BUILDKIT=1.
+
 # 2022-04-06
 
 * Removed the `libssl-dev` and `gdebi-core` system dependencies from the final

--- a/workbench/Dockerfile
+++ b/workbench/Dockerfile
@@ -120,8 +120,7 @@ COPY startup/* /startup/base/
 COPY startup-launcher/* /startup/launcher/
 COPY startup-user-provisioning/* /startup/user-provisioning/
 COPY supervisord.conf /etc/supervisor/supervisord.conf
-COPY startup.sh /usr/local/bin/startup.sh
-RUN chmod +x /usr/local/bin/startup.sh
+COPY --chmod=0775 startup.sh /usr/local/bin/startup.sh
 
 # Install RStudio Workbench --------------------------------------------------#
 ARG RSW_VERSION=2022.02.1+461.pro1
@@ -142,12 +141,11 @@ RUN rstudio-server install-vs-code /opt/code-server/
 
 # Copy config
 COPY conf/* /etc/rstudio/
-COPY sssd.conf /etc/sssd/sssd.conf
+COPY --chmod=600 sssd.conf /etc/sssd/sssd.conf
 
 # Create log dir
 RUN mkdir -p /var/lib/rstudio-server/monitor/log && \
     chown -R rstudio-server:rstudio-server /var/lib/rstudio-server/monitor && \
-    chmod 600 /etc/sssd/sssd.conf && \
     mkdir -p /startup/custom/ && \
     echo '\n# allow home directory creation\nsession required pam_mkhomedir.so skel=/etc/skel umask=0022' >> /etc/pam.d/common-session
 

--- a/workbench/NEWS.md
+++ b/workbench/NEWS.md
@@ -1,3 +1,8 @@
+# 2022-04-07
+
+- The Dockerfile now uses BuildKit features and must be built with
+  DOCKER_BUILDKIT=1.
+
 # 2021.09.0
 
 - **BREAKING**: rename environment variables to use `RSW_` prefix instead of `RSP_` prefix


### PR DESCRIPTION
Unfortunately, using `COPY` to move a file into an image followed by `RUN chmod` actually duplicates the file and creates an unnecessary image layer.

This commit makes use of the `--chmod` flag that was added to `COPY` for this exact reason in a few places. This flag is only supported by BuildKit, but that's what we use to build images anyway, so it seems like a reasonable win.