### PR TITLE
Install Package Manager with apt instead of gdebi

### DIFF
--- a/package-manager/Dockerfile
+++ b/package-manager/Dockerfile
@@ -26,13 +26,13 @@ EXPOSE 2112/tcp
 ARG RSPM_VERSION=2021.12.0-3
 ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu/amd64
 RUN apt-get update --fix-missing \
-    && apt-get install -y --no-install-recommends gdebi-core dpkg-sig \
+    && apt-get install -y --no-install-recommends dpkg-sig \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \
-    && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 gdebi -n rstudio-pm_${RSPM_VERSION}_amd64.deb \
+    && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 apt-get install -y --no-install-recommends ./rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \
-    && apt-get purge -y gdebi-core dpkg-sig \
+    && apt-get purge -y dpkg-sig \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/package-manager/Dockerfile
+++ b/package-manager/Dockerfile
@@ -26,7 +26,7 @@ EXPOSE 2112/tcp
 ARG RSPM_VERSION=2021.12.0-3
 ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu/amd64
 RUN apt-get update --fix-missing \
-    && apt-get install -y --no-install-recommends dpkg-sig \
+    && apt-get install -y --no-install-recommends dpkg-sig libssl1.0.0 \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \


### PR DESCRIPTION
This has a few advantages:

* We don't have to install (and later remove) `gdebi`.

* `ap`t allows us to skip installing Recommended packages. RSPM depends on `git` and `git` recommends `less` and `ssh-client` (yes, really), so we were previously installing an SSH client into the image. With this change neither of these packages nor their transitive dependencies are installed.

This shaves about 8M off the resulting image, too.