### PR TITLE
Remove the unused pandoc and TeX installations from the RSPM image

### DIFF
--- a/package-manager/Dockerfile
+++ b/package-manager/Dockerfile
@@ -1,13 +1,28 @@
-ARG R_VERSION=3.6.2
-FROM rstudio/r-base:${R_VERSION}-bionic
+FROM ubuntu:bionic
 LABEL maintainer="RStudio Docker <docker@rstudio.com>"
+
+# System dependendies and an R installation for package builds -----------------#
+ARG R_VERSION=3.6.2
+ARG R_DOWNLOAD_URL=https://cdn.rstudio.com/r/ubuntu-1804/pkgs
+RUN apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    locales \
+    && curl -O ${R_DOWNLOAD_URL}/r-${R_VERSION}_1_amd64.deb \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb \
+    && rm r-${R_VERSION}_1_amd64.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R \
+    && ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript \
+    && ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R
 
 # Locale configuration --------------------------------------------------------#
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ UTC
 
 ENV PATH /opt/rstudio-pm/bin:$PATH
 
@@ -25,7 +40,7 @@ EXPOSE 2112/tcp
 ARG RSPM_VERSION=2022.04.0-7
 ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu/amd64
 RUN apt-get update --fix-missing \
-    && apt-get install -y --no-install-recommends gdebi-core dpkg-sig \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gdebi-core dpkg-sig \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \


### PR DESCRIPTION
Previously the image was based on `rstudio/r-base`, which includes TinyTeX and pandoc. However RSPM's Git builds do not build package manuals or vignettes, so we don't actually need these programs.

This shaves about 300MB off the image size.

The upstream `rstudio/r-base` image also does the following, which we replicate directly instead:

* Install R from RStudio's own packages.

* Set `TZ=UTC`.

* Set the locale.