### PR TITLE
Azure handle bad license key

### DIFF
--- a/helper/workbench-for-microsoft-azure-ml/startup.sh
+++ b/helper/workbench-for-microsoft-azure-ml/startup.sh
@@ -28,11 +28,11 @@ RSP_LICENSE_SERVER=${RSP_LICENSE_SERVER:-${RSW_LICENSE_SERVER}}
 # Activate License
 RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}
 if [ -n "$RSP_LICENSE" ]; then
-    /usr/lib/rstudio-server/bin/license-manager activate $RSP_LICENSE
+    /usr/lib/rstudio-server/bin/license-manager activate $RSP_LICENSE || true
 elif [ -n "$RSP_LICENSE_SERVER" ]; then
-    /usr/lib/rstudio-server/bin/license-manager license-server $RSP_LICENSE_SERVER
+    /usr/lib/rstudio-server/bin/license-manager license-server $RSP_LICENSE_SERVER || true
 elif test -f "$RSW_LICENSE_FILE_PATH"; then
-    /usr/lib/rstudio-server/bin/license-manager activate-file $RSW_LICENSE_FILE_PATH
+    /usr/lib/rstudio-server/bin/license-manager activate-file $RSW_LICENSE_FILE_PATH || true
 fi
 
 # ensure these cannot be inherited by child processes


### PR DESCRIPTION
add `|| true` for all license activation commands

This should have the effect of catching / swallowing errors and allowing the startup script to continue. If licensing failed / fails, workbench should still start, but display our "licensing error" page to users so that they can resolve the issue in their environment.