### PR TITLE
build on the `dev-rspm` branch as well as `main`/`dev`

### DIFF
--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -60,6 +60,9 @@ jobs:
           if [[ "true" == "${{ github.ref == 'refs/heads/dev' }}" ]]; then
             BRANCH_PREFIX="dev-"
             echo "Setting BRANCH_PREFIX=$BRANCH_PREFIX-"
+          elif [[ "true" == "${{ github.ref == 'refs/heads/dev-rspm' }}" ]]; then
+            BRANCH_PREFIX="dev-rspm-"
+            echo "Setting BRANCH_PREFIX=$BRANCH_PREFIX-"
           else
             BRANCH_PREFIX=""
           fi
@@ -117,14 +120,14 @@ jobs:
           docker-compose -f ./${{ matrix.config.dir }}/docker-compose.test.yml run sut
 
       - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -132,7 +135,7 @@ jobs:
           password: ${{ secrets.BUILD_PAT }}
 
       - name: Push image(s) to Docker Hub
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
         run: |
           docker push rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
           docker push rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - dev
+      - dev-rspm
   pull_request:
 
 name: build/test/push (preview)
@@ -57,6 +58,9 @@ jobs:
           echo "::set-output name=SAFE_VERSION::${SAFE_VERSION}"
           if [[ "true" == "${{ github.ref == 'refs/heads/dev' }}" ]]; then
             BRANCH_PREFIX="dev-"
+            echo "Setting BRANCH_PREFIX=$BRANCH_PREFIX-"
+          elif [[ "true" == "${{ github.ref == 'refs/heads/dev-rspm' }}" ]]; then
+            BRANCH_PREFIX="dev-rspm-"
             echo "Setting BRANCH_PREFIX=$BRANCH_PREFIX-"
           else
             BRANCH_PREFIX=""
@@ -115,14 +119,14 @@ jobs:
           docker-compose -f ./${{ matrix.config.dir }}/docker-compose.test.yml run sut
 
       - name: Login to Docker Hub
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -130,7 +134,7 @@ jobs:
           password: ${{ secrets.BUILD_PAT }}
 
       - name: Push image(s) to Docker Hub
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
         run: |
           docker push rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
           docker push rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}


### PR DESCRIPTION
We may want to go to a wildcard at some point, but that may require some
re-architecting the workflow here. Hopefully this will be sufficient in
the short term (for #270 )