### PR TITLE
Build less frequently

### DIFF
--- a/.github/workflows/build-content.yaml
+++ b/.github/workflows/build-content.yaml
@@ -5,7 +5,7 @@ on:
       - dev
   pull_request:
 
-name: build/push RStudio Content Images
+name: build/push (content)
 jobs:
 
   matrix:
@@ -13,16 +13,24 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
       - id: set-matrix
         run: |
           MATRIX=$(jq -Mcr < content/matrix.json)
-          echo "::set-output name=matrix::$MATRIX"
+          MATRIX_DIFF_FILTER=$(echo "$MATRIX" | ./get-diffs.py -i -t origin/main)
+          echo "Filtered Diff Matrix: $MATRIX_DIFF_FILTER"
+          echo "::set-output name=matrix::$MATRIX_DIFF_FILTER"
 
   build:
     runs-on: ubuntu-latest
-    needs: matrix
     name: r${{ matrix.config.r }} py${{ matrix.config.py }} ${{ matrix.config.os }} ${{ github.ref }}
+    needs: matrix
 
     strategy:
       fail-fast: false
@@ -31,7 +39,15 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      # setup python
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -3,30 +3,54 @@ on:
     branches:
       - main
       - dev
+      - dev-rspm
   pull_request:
 
 name: build/test/push (latest)
 jobs:
 
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+      - id: set-matrix
+        run: |
+          # filter the matrix configuration
+          MATRIX=$(jq -Mcr < matrix-latest.json)
+          echo "Raw Matrix: $MATRIX"
+          MATRIX_DIFF_FILTER=$(echo "$MATRIX" | ./get-diffs.py -i -t origin/main)
+          echo "Filtered Diff Matrix: $MATRIX_DIFF_FILTER"
+          echo "::set-output name=matrix::$MATRIX_DIFF_FILTER"
+
   build:
     runs-on: ubuntu-latest
     name: build-${{ matrix.config.tag_prefix}}${{ matrix.config.product}}
+    needs: matrix
 
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - {product: 'rstudio-workbench', dir: 'workbench', os: 'bionic/amd64', prefix: RSW, version: 'latest'}
-          - {product: 'rstudio-connect', dir: 'connect', prefix: RSC, version: 'latest'}
-          - {product: 'rstudio-connect-content-init', dir: 'connect-content-init', prefix: RSC, version: 'latest'}
-          - {product: 'rstudio-package-manager', dir: 'package-manager', prefix: RSPM, version: 'latest'}
-          - {product: 'r-session-complete', tag_prefix: 'bionic-', dir: 'r-session-complete/bionic', os: 'bionic/amd64', prefix: RSW, version: 'latest'}
-          - {product: 'r-session-complete', tag_prefix: 'centos7-', dir: 'r-session-complete/centos7', os: 'centos7/x86_64', prefix: RSW, version: 'latest'}
-          - {product: 'rstudio-workbench-for-microsoft-azure-ml', dir: 'helper/workbench-for-microsoft-azure-ml', os: 'bionic/amd64', prefix: RSW, version: 'latest'}
+        config: ${{ fromJson(needs.matrix.outputs.matrix) }}
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      # setup python
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
 
       - name: Set up Docker Buildx
         id: buildx
@@ -117,7 +141,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.BUILD_PAT }}
 
-      - name: Push image(s) to Docker Hub
+      - name: Push image(s)
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           docker push rstudio/${{ matrix.config.product }}:${{ matrix.config.tag_prefix }}${{ matrix.config.version }}

--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -18,7 +18,13 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
       - id: set-matrix
         run: |
           # filter the matrix configuration
@@ -43,7 +49,15 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      # setup python
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -18,7 +18,13 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
       - id: set-matrix
         run: |
           # filter the matrix configuration
@@ -28,7 +34,9 @@ jobs:
           # NOTE: blank which input here means that every product is selected
           MATRIX_FILTER=$(echo "$MATRIX" | jq -Mcr 'map(select((.product | startswith("${{ github.event.inputs.which }}"))or("all"=="${{ github.event.inputs.which }}")))')
           echo "Filtered Matrix: $MATRIX_FILTER"
-          echo "::set-output name=matrix::$MATRIX_FILTER"
+          MATRIX_DIFF_FILTER=$(echo "$MATRIX_FILTER" | ./get-diffs.py -i -t origin/main)
+          echo "Filtered Diff Matrix: $MATRIX_DIFF_FILTER"
+          echo "::set-output name=matrix::$MATRIX_DIFF_FILTER"
 
   build:
     runs-on: ubuntu-latest
@@ -42,7 +50,15 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      # setup python
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ data
 *.lic
 .idea/
 tmp*/
+.python-version

--- a/matrix-latest.json
+++ b/matrix-latest.json
@@ -1,0 +1,9 @@
+[
+  {"product": "rstudio-workbench", "dir": "workbench", "os": "bionic/amd64", "prefix": "RSW", "version": "latest"},
+  {"product": "rstudio-connect", "dir": "connect", "prefix": "RSC", "version": "latest"},
+  {"product": "rstudio-connect-content-init", "dir": "connect-content-init", "prefix": "RSC", "version": "latest"},
+  {"product": "rstudio-package-manager", "dir": "package-manager", "prefix": "RSPM", "version": "latest"},
+  {"product": "r-session-complete", "tag_prefix": "bionic-", "dir": "r-session-complete/bionic", "os": "bionic/amd64", "prefix": "RSW", "version": "latest"},
+  {"product": "r-session-complete", "tag_prefix": "centos7-", "dir": "r-session-complete/centos7", "os": "centos7/x86_64", "prefix": "RSW", "version": "latest"},
+  {"product": "rstudio-workbench-for-microsoft-azure-ml", "dir": "helper/workbench-for-microsoft-azure-ml", "os": "bionic/amd64", "prefix": "RSW", "version": "latest"}
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
close #255 
- add a more robust computation of directory change
- add a check for "important_files"
- ensure that "preview-webhook" is not filtered by diffs (that feels inappropriate)

we ran into a case where a "subdirectory" of a watched directory changing (i.e. my/path, where we watch my/) would not get built. similarly, changing build infrastructure like our "version script" would not trigger new builds either.

A few open questions:
- should we remove `get-diffs.py` from the "important_files"
- should we consider _excluding_ unimportant files rather than _including_ important? i.e. should we err on the side of building too much (if a new file / directory is added) or too little (if a new global / CI affecting file is added and not added to "important_files")
- is there a better way to think about this problem?
- should we remove the "build protection" (build pass required to merge) since some builds may not run, now? Maybe a way to have an "outcome" build that succeeds only if all executed builds in the matrix pass, which we can require?
- should there be a way to ensure that "all builds get run"? Not sure what this would look like... a slash command or something?

TODO: ensure that builds will run on main when they land...