### PR TITLE
add custom azure-ml license manager to a dedicated path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ update-versions:  ## Update the version files for all products
 	@sed $(SED_FLAGS) "s|^RVersion.*=.*|RVersion = /opt/R/${R_VERSION}/|g" package-manager/rstudio-pm.gcfg
 	@sed $(SED_FLAGS) "s/^ARG RSW_VERSION=.*/ARG RSW_VERSION=${RSW_VERSION}/g" r-session-complete/bionic/Dockerfile
 	@sed $(SED_FLAGS) "s/^ARG RSW_VERSION=.*/ARG RSW_VERSION=${RSW_VERSION}/g" r-session-complete/centos7/Dockerfile
+	@sed $(SED_FLAGS) "s/^ARG RSW_VERSION=.*/ARG RSW_VERSION=${RSW_VERSION}/g" helper/workbench-for-microsoft-azure-ml/Dockerfile
 
 
 rsw: workbench

--- a/helper/workbench-for-microsoft-azure-ml/Dockerfile
+++ b/helper/workbench-for-microsoft-azure-ml/Dockerfile
@@ -135,7 +135,7 @@ COPY startup.sh /usr/local/bin/startup.sh
 RUN chmod +x /usr/local/bin/startup.sh
 
 # Install RStudio Workbench --------------------------------------------------#
-ARG RSW_VERSION=2021.09.2+382.pro1
+ARG RSW_VERSION=2022.02.2+485.pro2
 ARG RSW_DOWNLOAD_URL=https://download2.rstudio.org/server/bionic/amd64
 ARG RSW_NAME=rstudio-workbench
 RUN apt-get update --fix-missing \
@@ -143,6 +143,12 @@ RUN apt-get update --fix-missing \
     && curl -o rstudio-workbench.deb ${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb \
     && gdebi --non-interactive rstudio-workbench.deb \
     && rm rstudio-workbench.deb \
+    # custom license manager \
+    && mkdir -p /opt/rstudio-license/ \
+    && curl -sL https://s3.amazonaws.com/rstudio-ide-build/monitor/bionic/rsp-monitor-workbench-azureml-${RSW_VERSION_URL}.tar.gz |  \
+       tar xzvf - --strip 2 -C /opt/rstudio-license/ --wildcards '*/*/license-manager' \
+    && chown 0755 /opt/rstudio-license/license-manager \
+    && rm -f /usr/lib/rstudio-server/bin/license-manager \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/lib/rstudio-server/r-versions

--- a/helper/workbench-for-microsoft-azure-ml/conf/rserver.conf
+++ b/helper/workbench-for-microsoft-azure-ml/conf/rserver.conf
@@ -7,6 +7,8 @@ auth-proxy=1
 auth-proxy-sign-in-url=http://localhost:80/
 auth-proxy-user-header=x-custom-ms-user-name
 
+server-license-manager-path=/opt/rstudio-license/license-manager
+
 # Launcher Config
 launcher-address=127.0.0.1
 launcher-port=5559

--- a/helper/workbench-for-microsoft-azure-ml/startup.sh
+++ b/helper/workbench-for-microsoft-azure-ml/startup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LICENSE_MANAGER_PATH=${LICENSE_MANAGER_PATH:-/opt/rstudio-license}
+
 set -e
 set -x
 
@@ -8,7 +10,7 @@ deactivate() {
     echo "== Exiting =="
     rstudio-server stop
     echo "Deactivating license ..."
-    /usr/lib/rstudio-server/bin/license-manager deactivate >/dev/null 2>&1
+    ${LICENSE_MANAGER_PATH}/license-manager deactivate >/dev/null 2>&1
 
     echo "== Done =="
 }
@@ -28,11 +30,11 @@ RSP_LICENSE_SERVER=${RSP_LICENSE_SERVER:-${RSW_LICENSE_SERVER}}
 # Activate License
 RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}
 if [ -n "$RSP_LICENSE" ]; then
-    /usr/lib/rstudio-server/bin/license-manager activate $RSP_LICENSE || true
+    ${LICENSE_MANAGER_PATH}/license-manager activate $RSP_LICENSE || true
 elif [ -n "$RSP_LICENSE_SERVER" ]; then
-    /usr/lib/rstudio-server/bin/license-manager license-server $RSP_LICENSE_SERVER || true
+    ${LICENSE_MANAGER_PATH}/license-manager license-server $RSP_LICENSE_SERVER || true
 elif test -f "$RSW_LICENSE_FILE_PATH"; then
-    /usr/lib/rstudio-server/bin/license-manager activate-file $RSW_LICENSE_FILE_PATH || true
+    ${LICENSE_MANAGER_PATH}/license-manager activate-file $RSW_LICENSE_FILE_PATH || true
 fi
 
 # ensure these cannot be inherited by child processes


### PR DESCRIPTION
unpack the dedicated monitor build to /opt/rstudio/bin, configure
rserver.conf and statup.sh to point at the new binary