### PR TITLE
Update `LD_LIBRARY_PATH` so `license-manager` will work

### DIFF
--- a/helper/workbench-for-microsoft-azure-ml/Dockerfile
+++ b/helper/workbench-for-microsoft-azure-ml/Dockerfile
@@ -156,6 +156,7 @@ RUN apt-get update --fix-missing \
 
 # Custom license manager
 COPY --chmod=755 TurboActivate.dat /opt/rstudio-license/license-manager.conf
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rstudio-license
 
 # Install VSCode code-server --------------------------------------------------#
 

--- a/helper/workbench-for-microsoft-azure-ml/Dockerfile
+++ b/helper/workbench-for-microsoft-azure-ml/Dockerfile
@@ -149,14 +149,15 @@ RUN apt-get update --fix-missing \
     && curl -sL https://s3.amazonaws.com/rstudio-ide-build/monitor/bionic/rsp-monitor-workbench-azureml-${RSW_VERSION_URL}.tar.gz |  \
        tar xzvf - --strip 2 -C /opt/rstudio-license/ \
     && chmod 0755 /opt/rstudio-license/license-manager \
+    && mv /opt/rstudio-license/license-manager /opt/rstudio-license/license-manager-orig \
     && rm -f /usr/lib/rstudio-server/bin/license-manager \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/lib/rstudio-server/r-versions
 
 # Custom license manager
+COPY --chmod=755 license-manager-shim /opt/rstudio-license/license-manager
 COPY --chmod=755 TurboActivate.dat /opt/rstudio-license/license-manager.conf
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rstudio-license
 
 # Install VSCode code-server --------------------------------------------------#
 

--- a/helper/workbench-for-microsoft-azure-ml/license-manager-shim
+++ b/helper/workbench-for-microsoft-azure-ml/license-manager-shim
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Copyright (C) 2022 by RStudio, PBC.
+
+dir=$(dirname "$0")
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/rstudio-license"
+exec "$dir/license-manager-orig" "$@"


### PR DESCRIPTION
This _should_ be the final step in getting licensing to work. Currently, running `/opt/rstudio-license/license-manager status` gives the following:

```
root@59a99e525fa8:/# /opt/rstudio-license/license-manager status
/opt/rstudio-license/license-manager: error while loading shared libraries: librserver.so: cannot open shared object file: No such file or directory
However, if I navigate to /opt/rstudio-license and execute ./license-manager status I see the expected output:
root@59a99e525fa8:/opt/rstudio-license# ./license-manager status
RStudio License Manager 2022.02.2+485.pro2

-- Local license status --

Trial-Type: Verified
Status: Expired
Has-Key: No
Has-Trial: No
License-Scope: System
License-Engine: 4.4.3.0

-- Floating license status --

License server not in use.
```

So, I think this is a path issue, as evidenced by the following output:
```
root@59a99e525fa8:/opt/rstudio-license# ldd license-manager
        librserver.so (0x0000004001ed4000)
        librclient.so (0x000000400203f000)
        libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x000000400233f000)
        libuuid.so.1 => /lib/x86_64-linux-gnu/libuuid.so.1 (0x0000004002542000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x0000004002749000)
        libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x0000004002951000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x0000004002e1e000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x000000400303d000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00000040033c6000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00000040035de000)
        /lib64/ld-linux-x86-64.so.2 (0x0000004000000000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00000040039cf000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x0000004003d6d000)
root@59a99e525fa8:/opt/rstudio-license# cd /
root@59a99e525fa8:/# ldd /opt/rstudio-license/license-manager
        librserver.so => not found
        librclient.so => not found
        libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x0000004001edf000)
        libuuid.so.1 => /lib/x86_64-linux-gnu/libuuid.so.1 (0x00000040020e2000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00000040022e9000)
        libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00000040024f1000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00000040029be000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x0000004002bdd000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x0000004002f66000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000000400317e000)
        /lib64/ld-linux-x86-64.so.2 (0x0000004000000000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x000000400356f000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x0000004003773000)
```

Adding `/opt/rstudio-license` to `LD_LIBRARY_PATH` should resolve the issue, assuming it's the correct approach.