### PR TITLE
Use a consistent Launcher directory location for RSPM

### DIFF
--- a/package-manager/NEWS.md
+++ b/package-manager/NEWS.md
@@ -1,3 +1,14 @@
+# 2022-06-23
+
+- Git building now works when running Package Manager as `root` with a persistent
+  data directory. There is no longer a need to work around this issue by setting
+ `Launcher.ServerUser = root` and `Launcher.AdminGroup = root` in the configuration.
+- The Launcher directory is now set to a consistent location, `/data/launcher_internal`
+  in the default configuration. Previously, the Launcher directory location was based
+  on the container hostname, `/data/launcher_internal/[hostname]`, which may have
+  been different on each container restart. This would have caused unused files to
+  accrue in `/data/launcher_internal`.
+
 # 2022-04-07
 
 - The Dockerfile now uses BuildKit features and must be built with

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -60,10 +60,23 @@ See a complete example of that file at `package-manager/rstudio-pm.gcfg`.
 
 #### Persistent Data
 
-In order to persist Package Manager data between container restarts configure RSC `Server.DataDir` option to go to
+In order to persist Package Manager data between container restarts, configure the `Server.DataDir` option to go to
 a persistent volume. The included configuration file expects a persistent volume from the host machine or your docker
 orchestration system to be available at `/data`. Should you wish to move this to a different path, you can change the
 `Server.DataDir` option.
+
+When changing `Server.DataDir` to a custom location, we also recommend setting `Server.LauncherDir`
+to a consistent location within `Server.DataDir`, such as `{Server.DataDir}/launcher_internal`.
+The default location of `Server.LauncherDir` depends on the container's hostname, which may be
+different each time the container restarts.
+
+```ini
+[Server]
+DataDir = /mnt/rspm/data
+; Use a consistent location for the Launcher directory. The default location
+; is based on the hostname, and the hostname may be different in each container.
+LauncherDir = /mnt/rspm/data/launcher_internal
+```
 
 #### Licensing
 

--- a/package-manager/rstudio-pm-float.gcfg
+++ b/package-manager/rstudio-pm-float.gcfg
@@ -6,8 +6,9 @@ Listen = :4242
 
 [Server]
 DataDir = /data
-
-[Server]
+; Use a consistent location for the Launcher directory. The default location
+; is based on the hostname, and the hostname may be different in each container.
+LauncherDir = /data/launcher_internal
 RVersion = /opt/R/3.6.2/
 
 [Git]

--- a/package-manager/rstudio-pm.gcfg
+++ b/package-manager/rstudio-pm.gcfg
@@ -3,6 +3,9 @@ Listen = :4242
 
 [Server]
 DataDir = /data
+; Use a consistent location for the Launcher directory. The default location
+; is based on the hostname, and the hostname may be different in each container.
+LauncherDir = /data/launcher_internal
 RVersion = /opt/R/3.6.2/
 
 [Git]


### PR DESCRIPTION
Sets the RSPM Launcher directory to `/data/launcher_internal` to address two issues:

1. When running RSPM as root and the Launcher as the default `rstudio-pm` user, there's a permissions issue for the Launcher due to a bug in RSPM 2022.04.0 where RSPM only changes ownership of the last directory in the Launcher directory path. The default Launcher directory is `{DataDir}/launcher_internal/[hostname]`, so RSPM only changes ownership of `{DataDir}/launcher_internal/[hostname]`, not `{DataDir}/launcher_internal`. We added a workaround in the Docker image at https://github.com/rstudio/rstudio-docker-products/pull/269, but this doesn't work if you mount in a persistent data directory.

    By omitting the `[hostname]` part, the Launcher directory should now always be accessible to the Launcher user, even when using a persistent data directory. This directory ownership bug is fixed in the next  RSPM release.

   This problem has led to at least 2 support issues in recent weeks, and we've been giving the workaround of setting `Launcher.ServerUser = root` in the config.

2. The default Launcher directory is based on the hostname, `{DataDir}/launcher_internal/[hostname]`, and may be different each time the container restarts if you don't specify a consistent hostname in Docker. When using a persistent data directory, this will cause file pollution in the Launcher directory, and may cause issues with Launcher state not being persisted correctly.
```sh
# Before this change
$ ls -la /data/launcher_internal/
total 28
drwx------  7 rstudio-pm rstudio-pm 4096 Jun 13 22:20 .
drwxr-xr-x 13 root       root       4096 Jun 13 22:19 ..
drwxr-xr-x  5 rstudio-pm rstudio-pm 4096 Jun 13 22:20 48a411650b44
drwxr-xr-x  5 rstudio-pm rstudio-pm 4096 Jun 13 22:19 a0bed1c5eca6
drwxr-xr-x  5 rstudio-pm rstudio-pm 4096 Jun 13 22:19 af7ffcb14d15
drwxr-xr-x  5 rstudio-pm rstudio-pm 4096 Jun 13 22:20 ccaa191c9660
drwxr-xr-x  5 rstudio-pm rstudio-pm 4096 Jun 13 22:19 ee99f3548696

# After this change
$ ls -la /data/launcher_internal/
total 40
drwxr-xr-x  5 rstudio-pm rstudio-pm 4096 Jun 23 23:25 .
drwxr-xr-x 12 root       root       4096 Jun 23 23:25 ..
drwx------  3 rstudio-pm rstudio-pm 4096 Jun 23 23:24 custom_logs
drwx------  3 rstudio-pm rstudio-pm 4096 Jun 23 23:25 jobs
-rw-------  1 rstudio-pm rstudio-pm  519 Jun 23 23:25 launcher.conf
-rw-------  1 rstudio-pm rstudio-pm  200 Jun 23 23:25 launcher.kubernetes.conf
-rw-------  1 rstudio-pm rstudio-pm  206 Jun 23 23:25 launcher.kubernetes.profiles.conf
-rw-------  1 rstudio-pm rstudio-pm  212 Jun 23 23:25 launcher.local.conf
drwxrwxrwx  2 rstudio-pm rstudio-pm 4096 Jun 23 23:25 output
-rw-------  1 rstudio-pm rstudio-pm   36 Jun 23 23:25 secure-cookie-key
```

This default setting is currently undocumented due to a bug that we'll fix for the next RSPM release: https://docs.rstudio.com/rspm/admin/appendix/configuration/#Server.LauncherDir. Changing the Launcher directory here could cause issues with Launcher state persistence as well, but that's already been happening. And persistence issues are rare anyway - if Launcher job state is lost during a Git build, you can rerun the Git build - the bigger issue is the file pollution.

## Potential issues/questions
- The hostname was added to the default Launcher directory for cluster configurations, since each node in a cluster needs its own Launcher directory, and the collisions caused problems. This change will cause problems when running RSPM in a cluster, but is that a supported configuration in the images? I don't see any references to Postgres. If users are running these images in clusters, we'll need to document that you don't do this for Postgres, and that you should specify consistent hostnames instead (e.g., `docker run --hostname=rspm01`, `hostname: rspm01` in docker-compose).
  - An alternate workaround for the root issue would be to explicitly set `Launcher.ServerUser = rstudio-pm` if necessary
- Overriding the `Server.LauncherDir` setting adds some configuration overhead/confusion, since you have to ensure that it matches `Server.DataDir` any time you change `Server.DataDir`. Would it be better to address this problem in RSPM instead? Like adding a config setting to disable the `[hostname]` part so you don't have to know the `DataDir`. Or automatically removing `[hostname]` if RSPM has been configured to use Postgres.

## Testing
I've tested this with and without a persistent data dir, and confirmed that the Launcher now starts correctly in both cases, and that Git building now works by default:
```sh
docker run -it --rm --privileged \
    -p 4242:4242 \
    -e RSPM_LICENSE=$RSTUDIO_PM_LICENSE \
    --name rspm \
    rstudio/rstudio-package-manager:2022.04.0-7

docker run -it --rm --privileged \
    -p 4242:4242 \
    -v $PWD/data/rspm:/data \
    -e RSPM_LICENSE=$RSTUDIO_PM_LICENSE \
    --name rspm \
    rstudio/rstudio-package-manager:2022.04.0-7
```

I've also tested these changes with the `dev-rspm` branch that switches the running user to `rstudio-pm`. That branch will need to be updated if this merges, as there are some conflicts with the config file changes (we moved DataDir from `/data` to `/var/lib/rstudio-pm`)