### PR TITLE
Rename workbench jupyterlab extension - dev branch only

### DIFF
--- a/helper/workbench-for-microsoft-azure-ml/Dockerfile
+++ b/helper/workbench-for-microsoft-azure-ml/Dockerfile
@@ -55,10 +55,11 @@ RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.s
     /opt/python/jupyter/bin/conda install -y python==${JUPYTER_VERSION} && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh && \
     /opt/python/jupyter/bin/pip install \
-    jupyter==1.0.0 \
-    'jupyterlab<3.0.0' \
+    jupyter \
+    jupyterlab \
     rsp_jupyter \
-    rsconnect_jupyter && \
+    rsconnect_jupyter \
+    workbench_jupyterlab && \
     /opt/python/jupyter/bin/jupyter kernelspec remove python3 -f && \
     /opt/python/jupyter/bin/pip uninstall -y ipykernel
 

--- a/r-session-complete/bionic/Dockerfile
+++ b/r-session-complete/bionic/Dockerfile
@@ -76,7 +76,7 @@ ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     jupyter \
     jupyterlab \
-    jupyterlab-rsw \
+    workbench_jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter \
     rsconnect_python

--- a/r-session-complete/centos7/Dockerfile
+++ b/r-session-complete/centos7/Dockerfile
@@ -74,10 +74,10 @@ ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 RUN /opt/python/${PYTHON_VERSION}/bin/pip install \
     jupyter \
     jupyterlab \
-    jupyterlab-rsw \
     rsp_jupyter \
     rsconnect_jupyter \
-    rsconnect_python
+    rsconnect_python \
+    workbench_jupyterlab 
 
 RUN /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter && \
     /opt/python/${PYTHON_VERSION}/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter && \

--- a/workbench/Dockerfile
+++ b/workbench/Dockerfile
@@ -58,8 +58,8 @@ RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.s
     /opt/python/jupyter/bin/conda install -y python==${JUPYTER_VERSION} && \
     rm -rf Miniconda3-latest-Linux-x86_64.sh && \
     /opt/python/jupyter/bin/pip install \
-    jupyter==1.0.0 \
-    'jupyterlab<3.0.0' \
+    jupyter \
+    jupyterlab \
     rsp_jupyter \
     rsconnect_jupyter \
     workbench_jupyterlab && \

--- a/workbench/Dockerfile
+++ b/workbench/Dockerfile
@@ -61,7 +61,8 @@ RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.s
     jupyter==1.0.0 \
     'jupyterlab<3.0.0' \
     rsp_jupyter \
-    rsconnect_jupyter && \
+    rsconnect_jupyter \
+    workbench_jupyterlab && \
     /opt/python/jupyter/bin/jupyter kernelspec remove python3 -f && \
     /opt/python/jupyter/bin/pip uninstall -y ipykernel
 
@@ -138,9 +139,6 @@ RUN apt-get update --fix-missing \
 # Install VSCode code-server, extensions, etc. --------------------------------------------------#
 
 RUN rstudio-server install-vs-code /opt/code-server/ && \
-	wget https://rstudio-ide-build.s3.amazonaws.com/rsw-jupyterlab/jupyterlab_rsw-9.9.9-py3-none-any.whl && \
-	/opt/python/jupyter/bin/pip install ./jupyterlab_rsw-9.9.9-py3-none-any.whl && \
-	rm -rf ./jupyterlab_rsw-9.9.9-py3-none-any.whl && \
 	curl -L -o /quarto.vsix https://github.com/quarto-dev/quarto-vscode/raw/main/visx/quarto-1.14.0.vsix && \
 	ln -s /opt/code-server/bin/code-server /usr/local/bin/code-server
 


### PR DESCRIPTION
Rename the Workbench JupyterLab extension on the dev branch once https://github.com/rstudio/rstudio-pro/pull/3593 has been merged and a new build has been uploaded to PyPI. The build will fail on this branch until that has been done.

This should not be merged into main until RSW 2022.07.0 is released. 