### PR TITLE
Enable "entrypoint.d" for Connect image

### DIFF
--- a/connect/Dockerfile
+++ b/connect/Dockerfile
@@ -115,5 +115,8 @@ ENV RSC_LICENSE_SERVER ""
 COPY rstudio-connect.gcfg /etc/rstudio-connect/rstudio-connect.gcfg
 VOLUME ["/data"]
 
-ENTRYPOINT ["tini", "--"]
+COPY /docker-entrypoint.sh .
+COPY /docker-entrypoint.d/* /docker-entrypoint.d/
+ONBUILD COPY /docker-entrypoint.d/* /docker-entrypoint.d/
+ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 CMD ["/usr/local/bin/startup.sh"]

--- a/connect/docker-entrypoint.d/50-activate-license.sh
+++ b/connect/docker-entrypoint.d/50-activate-license.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Activate License
+RSC_LICENSE_FILE_PATH=${RSC_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
+if ! [ -z "$RSC_LICENSE" ]; then
+    /opt/rstudio-connect/bin/license-manager activate $RSC_LICENSE
+elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
+    /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
+elif test -f "$RSC_LICENSE_FILE_PATH"; then
+    /opt/rstudio-connect/bin/license-manager activate-file $RSC_LICENSE_FILE_PATH
+fi
+
+# ensure these cannot be inherited by child processes
+unset RSC_LICENSE
+unset RSC_LICENSE_SERVER

--- a/connect/docker-entrypoint.sh
+++ b/connect/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DIR=/docker-entrypoint.d
+if [[ -d "$DIR" ]]; then
+  /bin/run-parts --verbose "$DIR"
+fi
+
+exec "$@"

--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -10,19 +10,5 @@ deactivate() {
 }
 trap deactivate EXIT
 
-# Activate License
-RSC_LICENSE_FILE_PATH=${RSC_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
-if ! [ -z "$RSC_LICENSE" ]; then
-    /opt/rstudio-connect/bin/license-manager activate $RSC_LICENSE
-elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
-    /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
-elif test -f "$RSC_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file $RSC_LICENSE_FILE_PATH
-fi
-
-# ensure these cannot be inherited by child processes
-unset RSC_LICENSE
-unset RSC_LICENSE_SERVER
-
 # Start RStudio Connect
 /opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg


### PR DESCRIPTION
Uses the ideas at https://www.camptocamp.com/en/news-events/flexible-docker-entrypoints-scripts as starting point.

By adding new scripts to `/docker-entrypoint.d/` one can add additional steps to the start-up process. And if one runs the image with `CMD=bash` one gets into a state where all these steps have been applied.