### PR TITLE
Update `dev-rspm` branch for consistent Launcher directory fix

### DIFF
--- a/package-manager/NEWS.md
+++ b/package-manager/NEWS.md
@@ -1,3 +1,14 @@
+# 2022-06-23
+
+- Git building now works when running Package Manager as `root` with a persistent
+  data directory. There is no longer a need to work around this issue by setting
+ `Launcher.ServerUser = root` and `Launcher.AdminGroup = root` in the configuration.
+- The Launcher directory is now set to a consistent location, `/data/launcher_internal`
+  in the default configuration. Previously, the Launcher directory location was based
+  on the container hostname, `/data/launcher_internal/[hostname]`, which may have
+  been different on each container restart. This would have caused unused files to
+  accrue in `/data/launcher_internal`.
+
 # 2022-04-07
 
 - The Dockerfile now uses BuildKit features and must be built with

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -60,10 +60,23 @@ Be sure the config file has the `[HTTP].Listen` field configured. See a complete
 
 ## Persistent Data
 
-In order to persist Package Manager data between container restarts configure RSC `Server.DataDir` option to go to
+In order to persist Package Manager data between container restarts, configure the `Server.DataDir` option to go to
 a persistent volume. The included configuration file expects a persistent volume from the host machine or your docker
 orchestration system to be available at `/var/lib/rstudio-pm`. Should you wish to move this to a different path, you can change the
 `Server.DataDir` option.
+
+When changing `Server.DataDir` to a custom location, we also recommend setting `Server.LauncherDir`
+to a consistent location within `Server.DataDir`, such as `{Server.DataDir}/launcher_internal`.
+The default location of `Server.LauncherDir` depends on the container's hostname, which may be
+different each time the container restarts.
+
+```ini
+[Server]
+DataDir = /mnt/rspm/data
+; Use a consistent location for the Launcher directory. The default location
+; is based on the hostname, and the hostname may be different in each container.
+LauncherDir = /mnt/rspm/data/launcher_internal
+```
 
 ## Licensing
 

--- a/package-manager/rstudio-pm-float.gcfg
+++ b/package-manager/rstudio-pm-float.gcfg
@@ -16,6 +16,11 @@ RVersion = /opt/R/3.6.2/
 ; Customize the data directory if necessary. This is where all packages and metadata are
 ; stored by default. Refer to Admin Guide for details.
 ;DataDir = /mnt/rspm/data
+;
+; Use a consistent location for the Launcher directory. The default location
+; is based on the hostname, and the hostname may be different in each container.
+; When customizing the data directory, this should be set to {DataDir}/launcher_internal
+LauncherDir = /var/lib/rstudio-pm/launcher_internal
 
 [HTTP]
 ; RStudio Package Manager will listen on this network address for HTTP connections.

--- a/package-manager/rstudio-pm.gcfg
+++ b/package-manager/rstudio-pm.gcfg
@@ -16,6 +16,11 @@ RVersion = /opt/R/3.6.2/
 ; Customize the data directory if necessary. This is where all packages and metadata are
 ; stored by default. Refer to Admin Guide for details.
 ;DataDir = /mnt/rspm/data
+;
+; Use a consistent location for the Launcher directory. The default location
+; is based on the hostname, and the hostname may be different in each container.
+; When customizing the data directory, this should be set to {DataDir}/launcher_internal
+LauncherDir = /var/lib/rstudio-pm/launcher_internal
 
 [HTTP]
 ; RStudio Package Manager will listen on this network address for HTTP connections.


### PR DESCRIPTION
Updates the `dev-rspm` branch for the consistent Launcher directory fix, https://github.com/rstudio/rstudio-docker-products/pull/335. This wasn't straightforward because https://github.com/rstudio/rstudio-docker-products/pull/335 conflicted with the `dev-rspm` branch (we moved `DataDir` from `/data` to `/var/lib/rstudio-pm`).

What I did was rebase `dev-rspm` against `main` before that PR merged (https://github.com/rstudio/rstudio-docker-products/commit/dc36cdc58d79a151367a147b926ab30f0e4d771d), then merged `main` into a branch based on `dev-rspm`, and manually resolved conflicts, changing `LauncherDir = /data/launcher_internal` to `LauncherDir = /var/lib/rstudio-pm/launcher_internal`. This lets the `dev-rspm` branch merge cleanly into `main` again, but adds some extra merge commits. Alternatively, I could try a complete rebase if that's better, but that would be harder to review on GitHub I think.

I noticed that the `dev-rspm` branch still needs a NEWS item with the root->non-root and data directory changes, but didn't add that here, just an FYI before we merge back to `main`.

Testing is similar to https://github.com/rstudio/rstudio-docker-products/pull/335. Without a persistent data directory, confirm that RSPM starts up and that the `/var/lib/rstudio-pm/launcher_internal` is initialized as the launcher data directory:

```sh
docker run -it --rm \
    -p 4242:4242 \
    -e RSPM_LICENSE=$RSTUDIO_PM_LICENSE \
    --name rspm \
    rstudio/rstudio-package-manager:2022.04.0-7

docker exec rspm ls -la /var/lib/rstudio-pm/launcher_internal
# total 40
# drwxr-xr-x 5 rstudio-pm rstudio-pm 4096 Jun 30 20:27 .
# drwx------ 1 rstudio-pm rstudio-pm 4096 Jun 30 20:27 ..
# drwx------ 3 rstudio-pm rstudio-pm 4096 Jun 30 20:27 custom_logs
# drwx------ 3 rstudio-pm rstudio-pm 4096 Jun 30 20:27 jobs
# -rw------- 1 rstudio-pm rstudio-pm  562 Jun 30 20:27 launcher.conf
# -rw------- 1 rstudio-pm rstudio-pm  228 Jun 30 20:27 launcher.kubernetes.conf
# -rw------- 1 rstudio-pm rstudio-pm  206 Jun 30 20:27 launcher.kubernetes.profiles.conf
# -rw------- 1 rstudio-pm rstudio-pm  240 Jun 30 20:27 launcher.local.conf
# drwxrwxrwx 2 rstudio-pm rstudio-pm 4096 Jun 30 20:27 output
# -rw------- 1 rstudio-pm rstudio-pm   36 Jun 30 20:27 secure-cookie-key
```

With a persistent data directory, confirm that `{DataDir}/launcher_internal` is used as the Launcher dir and persisted correctly:
```sh
# Work around existing permissions issue with the dev-rspm branch's root->non-root switch
mkdir -p data/rspm
sudo chown 999:999 -R data/rspm

docker run -it --rm \
    -p 4242:4242 \
    -v $PWD/data/rspm:/var/lib/rstudio-pm \
    -e RSPM_LICENSE=$RSTUDIO_PM_LICENSE \
    --name rspm \
    rstudio/rstudio-package-manager:2022.04.0-7

ls data/rspm/launcher_internal/ -la
# total 40
# drwxr-xr-x  5 systemd-coredump systemd-coredump 4096 Jun 30 15:30 .
# drwxr-xr-x 13 systemd-coredump systemd-coredump 4096 Jun 30 15:30 ..
# drwx------  3 systemd-coredump systemd-coredump 4096 Jun 30 15:30 custom_logs
# drwx------  3 systemd-coredump systemd-coredump 4096 Jun 30 15:30 jobs
# -rw-------  1 systemd-coredump systemd-coredump  561 Jun 30 15:30 launcher.conf
# -rw-------  1 systemd-coredump systemd-coredump  228 Jun 30 15:30 launcher.kubernetes.conf
# -rw-------  1 systemd-coredump systemd-coredump  206 Jun 30 15:30 launcher.kubernetes.profiles.conf
# -rw-------  1 systemd-coredump systemd-coredump  240 Jun 30 15:30 launcher.local.conf
# drwxrwxrwx  2 systemd-coredump systemd-coredump 4096 Jun 30 15:30 output
# -rw-------  1 systemd-coredump systemd-coredump   36 Jun 30 15:30 secure-cookie-key
```