### PR TITLE
switch to using the structured logging configuration for RSC

### DIFF
--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,9 @@
+# 2022-07-11
+
+- Switch container default configuration to use the `Logging` configuration
+  section. [See the docs](https://docs.rstudio.com/connect/admin/logging/) for
+  more info
+
 # 2022-04-07
 
 - The Dockerfile now uses BuildKit features and must be built with

--- a/connect/rstudio-connect-float.gcfg
+++ b/connect/rstudio-connect-float.gcfg
@@ -41,3 +41,11 @@ Executable = /opt/python/3.6.5/bin/python
 ;
 ;[RPackageRepository "RSPM"]
 ;URL = https://demo.rstudiopm.com/all/__linux__/bionic/latest
+
+[Logging]
+Enabled = true
+ServiceLog = STDOUT
+ServiceLogFormat = TEXT    ; TEXT or JSON
+ServiceLogLevel = INFO     ; INFO, WARNING or ERROR
+AccessLog = STDOUT
+AccessLogFormat = COMMON   ; COMMON, COMBINED, or JSON

--- a/connect/rstudio-connect.gcfg
+++ b/connect/rstudio-connect.gcfg
@@ -38,3 +38,11 @@ URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
 
 [RPackageRepository "RSPM"]
 URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+
+[Logging]
+Enabled = true
+ServiceLog = STDOUT
+ServiceLogFormat = TEXT    ; TEXT or JSON
+ServiceLogLevel = INFO     ; INFO, WARNING or ERROR
+AccessLog = STDOUT
+AccessLogFormat = COMMON   ; COMMON, COMBINED, or JSON


### PR DESCRIPTION
Connect now has a structured logging implementation. This switches the default Connect container configuration to use this value ahead of the defaults changing in the product. 

https://docs.rstudio.com/connect/admin/logging/