### PR TITLE
#349 Remove privileged containers requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-workbench-i:
 run-rsw: run-workbench
 run-workbench:  ## Run RSW container
 	docker rm -f rstudio-workbench
-	docker run -it --privileged \
+	docker run -it \
 		--name rstudio-workbench \
 		-p 8787:8787 \
 		-v $(PWD)/workbench/conf:/etc/rstudio/ \
@@ -142,7 +142,7 @@ test-package-manager-i:
 run-rspm: run-package-manager
 run-package-manager:  ## Run RSPM container
 	docker rm -f rstudio-package-manager
-	docker run -it --privileged \
+	docker run -it \
 		--name rstudio-package-manager \
 		-p 4242:4242 \
 		-v $(CURDIR)/data/rspm:/data \

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ changed in each image.
 
 This file only captures pervasive, repository-wide changes.
 
+# 2022-07
+
+- All containers, with the exception of RStudio Connect, may now be run as unprivileged. Please see
+  [RStudio Professional Product Root & Privileged Requirements](https://support.rstudio.com/hc/en-us/articles/1500005369282)
+  for additional information.
+
 # 2021-10
 
 - *BREAKING*: Rstudio Server Pro has Been Renamed to `Rstudio Workbench`

--- a/README.md
+++ b/README.md
@@ -66,10 +66,9 @@ docker-compose up
 
 # Privileged Containers
 
-Each of these images uses the `--privileged`
-flag for user and code isolation and security. Each product differs in the exact reasons why, but we would love to hear
-from you if this is concerning in your infrastructure.
-See [RStudio Professional Product Root & Privileged Requirements](https://support.rstudio.com/hc/en-us/articles/1500005369282)
+As of July 2022, only the RStudio Connect container uses the `--privileged` flag for user and code isolation and 
+security and all other images can be run unprivileged. Please see 
+[RStudio Professional Product Root & Privileged Requirements](https://support.rstudio.com/hc/en-us/articles/1500005369282)
 for more information.
 
 If you have feedback on any of our professional products, please always feel free to reach

--- a/connect-content-init/docker-compose.test.yml
+++ b/connect-content-init/docker-compose.test.yml
@@ -5,7 +5,6 @@ services:
     image: $IMAGE_NAME
     command: /run_tests.sh
     entrypoint: []
-    privileged: true
     environment:
       # uses .env by default
       - RSC_VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       args:
         RSW_VERSION: 2022.07.0+548.pro5
     image: rstudio/rstudio-workbench:2022.07.0-548.pro5
-    privileged: true
     environment:
       RSW_LICENSE: ${RSW_LICENSE}
       LICENSE_SERVER: ${RSW_LICENSE_SERVER}
@@ -43,7 +42,6 @@ services:
       args:
         RSPM_VERSION: 2022.07.0-9
     image: rstudio/rstudio-package-manager:2022.07.0-9
-    privileged: true
     environment:
       RSPM_LICENSE: ${RSPM_LICENSE}
       LICENSE_SERVER: ${RSPM_LICENSE_SERVER}

--- a/helper/float/README.md
+++ b/helper/float/README.md
@@ -35,7 +35,7 @@ export RSC_LICENSE_SERVER=rsc-float-lic:8999
 export RSPM_LICENSE_SERVER=rspm-float-lic:8969
 
 # RStudio Workbench
-docker run --privileged -it \
+docker run -it \
     -p 8787:8787 -p 5559:5559 \
     -v $PWD/data/rsw:/home \
     -v $PWD/workbench/conf/:/etc/rstudio \
@@ -53,7 +53,7 @@ docker run -it --privileged \
     rstudio/rstudio-connect:1.8.0.3-19
 
 # RStudio Package Manager
-docker run -it --privileged \
+docker run -it \
     -p 4242:4242 \
     -v $PWD/data/rspm:/data \
     -v $PWD/package-manager/rstudio-pm-float.gcfg:/etc/rstudio-pm/rstudio-pm.gcfg \

--- a/package-manager/docker-compose.test.yml
+++ b/package-manager/docker-compose.test.yml
@@ -4,7 +4,6 @@ services:
   sut:
     image: $IMAGE_NAME
     command: /run_tests.sh
-    privileged: true
     entrypoint: []
     environment:
       # uses .env by default

--- a/workbench/NEWS.md
+++ b/workbench/NEWS.md
@@ -1,3 +1,7 @@
+# 2022-07-25
+
+- Added `conf/launcher.local.conf` with `unprivileged=1` flag so the Local Launcher Plugin starts in unprivileged mode.
+
 # 2022-04-07
 
 - The Dockerfile now uses BuildKit features and must be built with

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -29,7 +29,7 @@ To verify basic functionality as a first step:
 export RSW_LICENSE=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
 
 # Run without persistent data using default configuration
-docker run --privileged -it \
+docker run -it \
     -p 8787:8787 \
     -e RSW_LICENSE=$RSW_LICENSE \
     rstudio/rstudio-workbench:latest
@@ -41,8 +41,7 @@ For a more "real" deployment, continue reading!
 
 ### Overview
 
-Note that running the RStudio Workbench Docker image requires the container to run using the `--privileged` flag and a
-valid RStudio Workbench license.
+Note that running the RStudio Workbench Docker image requires a valid RStudio Workbench license.
 
 This container includes:
 
@@ -106,7 +105,7 @@ Then:
 # sssd is picky about file permissions
 chmod 600 sssd.conf
 
-docker run --privileged -it \
+docker run -it \
     -p 8787:8787 -p 5559:5559 \
     -v $PWD/data/rsp:/home \
     -v $PWD/server-pro/conf/:/etc/rstudio \
@@ -147,14 +146,14 @@ more information.
 export RSW_LICENSE=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
 
 # Run without persistent data and using an external configuration
-docker run --privileged -it \
+docker run -it \
     -p 8787:8787 -p 5559:5559 \
     -v $PWD/workbench/conf/:/etc/rstudio \
     -e RSW_LICENSE=$RSW_LICENSE \
     rstudio/rstudio-workbench:latest
 
 # Run with persistent data and using an external configuration
-docker run --privileged -it \
+docker run -it \
     -p 8787:8787 -p 5559:5559 \
     -v $PWD/data/rsw:/home \
     -v $PWD/workbench/conf/:/etc/rstudio \

--- a/workbench/conf/launcher.local.conf
+++ b/workbench/conf/launcher.local.conf
@@ -1,0 +1,1 @@
+unprivileged=1


### PR DESCRIPTION
- Removed `--privileged` flag for all documentation and definitions/scripts except for Connect.
- Added NEWS entry for change with link to Privileged Requirements support article.