### PR TITLE
Update get-version.py to use elsbeth-geranium index.json

### DIFF
--- a/get-version.py
+++ b/get-version.py
@@ -91,7 +91,7 @@ def clean_product_selection(product: str) -> str:
 
 
 def rstudio_workbench_daily():
-    version_json = download_json("https://dailies.rstudio.com/rstudio/spotted-wakerobin/index.json")
+    version_json = download_json("https://dailies.rstudio.com/rstudio/elsbeth-geranium/index.json")
     return version_json['workbench']['platforms']['bionic']['version']
 
 


### PR DESCRIPTION
Updates get-version script to use the latest index.json for elsbeth-geranium builds.