### PR TITLE
Refactor Preview Workflow

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -13,59 +13,35 @@ on:
 name: build/test/push (preview)
 jobs:
 
-  matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v2
-      - id: set-matrix
-        run: |
-          # filter the matrix configuration
-          MATRIX=$(jq -Mcr < matrix-preview.json)
-          echo "Raw Matrix: $MATRIX"
-          echo "Input - which: ${{ github.event.inputs.which }}"
-          # NOTE: blank which input here means that every product is selected
-          MATRIX_FILTER=$(echo "$MATRIX" | jq -Mcr 'map(select((.product | startswith("${{ github.event.inputs.which }}"))or("all"=="${{ github.event.inputs.which }}")))')
-          echo "Filtered Matrix: $MATRIX_FILTER"
-          echo "::set-output name=matrix::$MATRIX_FILTER"
 
   build:
     runs-on: ubuntu-latest
-    name: build-${{ matrix.config.tag_prefix }}${{ matrix.config.product }}:${{ matrix.config.version }}
-    needs: matrix
+    name: build-${{ matrix.config.product }}:${{ matrix.config.type }}:${{ matrix.config.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        config: ${{ fromJson(needs.matrix.outputs.matrix) }}
+        config:
+         - {product: "workbench", type: "daily", os: "bionic"}
+         - {product: "workbench", type: "preview", os: "bionic"}
+         - {product: "connect", type: "daily", os: "bionic"}
+         - {product: "connect-content-init", type: "daily", os: "bionic"}
+         - {product: "package-manager", type: "daily", os: "bionic"}
+         - {product: "r-session-complete", type: "daily", os: "bionic"}
+         - {product: "r-session-complete", type: "daily", os: "centos7"}
+         - {product: "r-session-complete", type: "preview", os: "bionic"}
+         - {product: "r-session-complete", type: "preview", os: "centos7"}
 
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v2
 
+      - name: Set up Just
+        uses: extractions/setup-just@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Get version
-        id: version
-        run: |
-          # NOTE: --local ensures that "latest" builds use the version in our Makefile (instead of latest from the web)
-          VERSION=`./get-version.py ${{ matrix.config.product }} --type=${{ matrix.config.version }} --local`
-          SAFE_VERSION=`echo -n "$VERSION" | sed 's/+/-/g'`
-          echo "::set-output name=VERSION::${VERSION}"
-          echo "::set-output name=SAFE_VERSION::${SAFE_VERSION}"
-          if [[ "true" == "${{ github.ref == 'refs/heads/dev' }}" ]]; then
-            BRANCH_PREFIX="dev-"
-            echo "Setting BRANCH_PREFIX=$BRANCH_PREFIX-"
-          elif [[ "true" == "${{ github.ref == 'refs/heads/dev-rspm' }}" ]]; then
-            BRANCH_PREFIX="dev-rspm-"
-            echo "Setting BRANCH_PREFIX=$BRANCH_PREFIX-"
-          else
-            BRANCH_PREFIX=""
-          fi
-          echo "::set-output name=BRANCH_PREFIX::${BRANCH_PREFIX}"
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -75,31 +51,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: ./${{ matrix.config.dir }}
-          file: ./${{ matrix.config.dir }}/Dockerfile.${{ matrix.config.os }}
-          builder: ${{ steps.buildx.outputs.name }}
-          tags: |
-            rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
-            rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
-            ghcr.io/rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
-            ghcr.io/rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          load: true
-          push: false
-          build-args: |
-            RSW_VERSION=${{ steps.version.outputs.VERSION }}
-            RSC_VERSION=${{ steps.version.outputs.VERSION }}
-            RSPM_VERSION=${{ steps.version.outputs.VERSION }}
-            # TODO: need a better way to handle pivoting DOWNLOAD_URL for OS
-            RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/${{ matrix.config.os }}/${{ matrix.config.arch }}
-
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Build Image
+        id: build-image
+        run: |
+          TAGS=`just BUILDX_PATH=${{ steps.buildx.outputs.name }} build-preview ${{ matrix.config.type }} ${{ matrix.config.product }} ${{ matrix.config.os }}`
+          echo "::set-output name=TAGS::$TAGS"
 
       - name: Show image size
         run: |
@@ -107,16 +63,11 @@ jobs:
 
       - name: Test image
         env:
-          IMAGE_NAME: rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
-          # because we cannot dynamically set env var names... set them all...
-          RSW_VERSION: ${{ steps.version.outputs.VERSION }}
-          RSC_VERSION: ${{ steps.version.outputs.VERSION }}
-          RSPM_VERSION: ${{ steps.version.outputs.VERSION }}
           RSC_LICENSE: ${{ secrets.RSC_LICENSE }}
           RSPM_LICENSE: ${{ secrets.RSPM_LICENSE }}
           RSW_LICENSE: ${{ secrets.RSW_LICENSE }}
         run: |
-          docker-compose -f ./${{ matrix.config.dir }}/docker-compose.test.yml run sut
+          just test-image ${{ matrix.config.type }} ${{ matrix.config.product }} ${{ steps.build-image.outputs.TAGS }}
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
@@ -136,7 +87,4 @@ jobs:
       - name: Push image(s) to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
         run: |
-          docker push rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
-          docker push rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
-          docker push ghcr.io/rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ matrix.config.version }}
-          docker push ghcr.io/rstudio/${{ matrix.config.product }}:${{ steps.version.outputs.BRANCH_PREFIX }}${{ matrix.config.tag_prefix }}${{ steps.version.outputs.SAFE_VERSION }}
+          just push-images ${{ steps.build-image.outputs.TAGS }}

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -51,10 +51,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
+      - name: Get Version
+        id: get-version
+        run: |
+          VERSION=`just get-version ${{ matrix.config.product }} --type=${{ matrix.config.type }} --local`
+          echo "::set-output name=VERSION::$VERSION"
+
       - name: Build Image
         id: build-image
         run: |
-          TAGS=`just BUILDX_PATH=${{ steps.buildx.outputs.name }} build-preview ${{ matrix.config.type }} ${{ matrix.config.product }} ${{ matrix.config.os }}`
+          TAGS=`just BUILDX_PATH=${{ steps.buildx.outputs.name }} build-preview ${{ matrix.config.type }} ${{ matrix.config.product }} ${{ matrix.config.os }} ${{ steps.get-version.outputs.VERSION }}`
           echo "::set-output name=TAGS::$TAGS"
 
       - name: Show image size
@@ -67,7 +73,7 @@ jobs:
           RSPM_LICENSE: ${{ secrets.RSPM_LICENSE }}
           RSW_LICENSE: ${{ secrets.RSW_LICENSE }}
         run: |
-          just test-image ${{ matrix.config.type }} ${{ matrix.config.product }} ${{ steps.build-image.outputs.TAGS }}
+          just test-image ${{ matrix.config.type }} ${{ matrix.config.product }} ${{  steps.get-version.outputs.VERSION }} ${{ steps.build-image.outputs.TAGS }}
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}

--- a/Justfile
+++ b/Justfile
@@ -100,7 +100,8 @@ build-preview $TYPE $PRODUCT $OS $VERSION $BRANCH=`git branch --show`:
     BUILDX_ARGS="--cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache"
   fi
 
-  docker buildx --builder="{{BUILDX_PATH}}" build --load $BUILDX_ARGS -t rstudio/rstudio-"$PRODUCT"-preview:"${BRANCH_PREFIX}${OS}"-"$TAG_VERSION" \
+  docker buildx --builder="{{BUILDX_PATH}}" build --load $BUILDX_ARGS \
+        -t rstudio/rstudio-"$PRODUCT"-preview:"${BRANCH_PREFIX}${OS}"-"$TAG_VERSION" \
         -t rstudio/rstudio-"$PRODUCT"-preview:"${BRANCH_PREFIX}${OS}"-"$TYPE" \
         -t ghcr.io/rstudio/rstudio-"$PRODUCT"-preview:"${BRANCH_PREFIX}${OS}"-"$TAG_VERSION" \
         -t ghcr.io/rstudio/rstudio-"$PRODUCT"-preview:"${BRANCH_PREFIX}${OS}"-"$TYPE" \
@@ -108,6 +109,7 @@ build-preview $TYPE $PRODUCT $OS $VERSION $BRANCH=`git branch --show`:
         --build-arg RSW_DOWNLOAD_URL=$RSW_DOWNLOAD_URL \
         --file=./"$PRODUCT"/Dockerfile."$OS" "$PRODUCT"
 
+  # These tags are propogated forward to test-images and push-images in builds. It is important that these tags match the build tags above.
   echo rstudio/rstudio-"${PRODUCT}"-preview:"${BRANCH_PREFIX}${OS}"-"${TAG_VERSION}" \
         rstudio/rstudio-"${PRODUCT}"-preview:"${BRANCH_PREFIX}""${OS}"-"${TYPE}" \
         ghcr.io/rstudio/rstudio-"${PRODUCT}"-preview:"${BRANCH_PREFIX}${OS}"-"${TAG_VERSION}" \

--- a/Justfile
+++ b/Justfile
@@ -128,6 +128,7 @@ _rsw-download-url TYPE OS:
     echo "https://s3.amazonaws.com/rstudio-ide-build/server/{{OS}}/{{ if OS == "centos7" { "x86_64"} else { "amd64" } }}"
   fi
 
+# just push-images tag1 tag2 ...
 push-images +IMAGES:
   #!/usr/bin/env bash
   set -euxo pipefail
@@ -136,6 +137,7 @@ push-images +IMAGES:
     docker push $IMAGE
   done
 
+# just test-image preview workbench tag1 tag2 tag3 ...
 test-image $TYPE $PRODUCT +IMAGES:
   #!/usr/bin/env bash
   set -euxo pipefail
@@ -150,9 +152,11 @@ test-image $TYPE $PRODUCT +IMAGES:
     IMAGE_NAME="${IMAGE_ARRAY[0]}" RSW_VERSION="$REAL_VERSION" RSC_VERSION="$REAL_VERSION" RSPM_VERSION="$REAL_VERSION" \
     docker-compose -f docker-compose.test.yml run sut
 
+# just get-version workbench --type=preview --local
 get-version +NARGS:
   ./get-version.py {{NARGS}}
 
+# just get-safe-version workbench --type=preview --local
 get-safe-version +NARGS:
   #!/usr/bin/env bash
   VERSION=`./get-version.py {{NARGS}}`

--- a/Justfile
+++ b/Justfile
@@ -87,7 +87,7 @@ build-preview $TYPE $PRODUCT $OS $VERSION="" $BRANCH=`git branch --show`:
   fi
 
   # set short name and tag version
-  if [[ $PRODUCT == "workbench" ]]; then
+  if [[ $PRODUCT == "workbench" || $PRODUCT == "r-session-complete" ]]; then
     SHORT_NAME="RSW"
     RSW_DOWNLOAD_URL=`just _rsw-download-url $TYPE $OS`
   elif [[ $PRODUCT == "connect" ]]; then


### PR DESCRIPTION
### Changes
Add these build targets to Justfile:
- `build-preview`
- `_rsw-download-url`
- `push-images`
- `test-image`
- `get-version`
- `get-safe-version`

Modify `build-preview.yaml` to use new Justfile targets.

### Motivation
Our current GH Actions contain a lot of logic for getting product versions, generating image tags, and etc. This is not ideal as this logic is duplicated and slightly modified among `build-preview`, `build-preview-webhook`, and `build-latest`. Moving this logic to the `Justfile` will prevent code duplication and make future maintenance easier.

### Testing
If you use [act](https://github.com/nektos/act) make sure you choose the largest image, otherwise docker-compose will not work. *this is a 20 gb image*

### Notes
`BUILDX_PATH` was added as a global Justfile variable because it removes the need for a positional argument within `build-preview` and can be useful locally to anyone who wants to store their `BUILDX_PATH`. If it is empty it is simply ignored.

`build-preview` outputs a list of images built to stdout. These tags will later be used by `push-images` and `test-image`.