### PR TITLE
fix get-version.py script to look up bionic properly

### DIFF
--- a/get-version.py
+++ b/get-version.py
@@ -92,7 +92,7 @@ def clean_product_selection(product: str) -> str:
 
 def rstudio_workbench_daily():
     version_json = download_json("https://dailies.rstudio.com/rstudio/elsbeth-geranium/index.json")
-    return version_json['workbench']['platforms']['bionic']['version']
+    return version_json['workbench']['platforms']['bionic-amd64']['version']
 
 
 def download_json(url):


### PR DESCRIPTION
now that RSW has multi-arch builds