### PR TITLE
Fix makefile Dockerfile build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ update-drivers:  ## Update the driver version
 
 rsw: workbench
 workbench:  ## Build Workbench image
-	docker build -t rstudio/rstudio-workbench:$(RSW_TAG_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSW_VERSION=$(RSW_VERSION) workbench
+	DOCKER_BUILDKIT=1 docker build -t rstudio/rstudio-workbench:$(RSW_TAG_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSW_VERSION=$(RSW_VERSION) --file workbench/Dockerfile.bionic workbench
 
 test-rsw: test-workbench
 test-workbench:
@@ -88,7 +88,7 @@ run-workbench:  ## Run RSW container
 
 rsc: connect
 connect:  ## Build RSC image
-	docker build -t rstudio/rstudio-connect:$(RSC_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSC_VERSION=$(RSC_VERSION) connect
+	DOCKER_BUILDKIT=1 docker build -t rstudio/rstudio-connect:$(RSC_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSC_VERSION=$(RSC_VERSION) --file connect/Dockerfile.bionic connect
 
 test-rsc: test-connect
 test-connect:
@@ -112,7 +112,7 @@ run-connect:  ## Run RSC container
 
 rspm: package-manager
 package-manager:  ## Build RSPM image
-	docker build -t rstudio/rstudio-package-manager:$(RSPM_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSPM_VERSION=$(RSPM_VERSION) package-manager
+	DOCKER_BUILDKIT=1 docker build -t rstudio/rstudio-package-manager:$(RSPM_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSPM_VERSION=$(RSPM_VERSION) --file package-manager/Dockerfile.bionic package-manager
 
 
 test-rspm: test-package-manager

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+IMAGE_OS ?= bionic
+
 R_VERSION ?= 3.6.2
 R_VERSION_ALT ?= 4.1.0
 
@@ -51,7 +53,7 @@ all: help
 
 
 images: workbench connect package-manager  ## Build all images
-	docker-compose build
+	DOCKER_BUILDKIT=1 IMAGE_OS=$(IMAGE_OS) docker-compose build
 
 
 update-versions:  ## Update the version files for all products
@@ -64,7 +66,7 @@ update-drivers:  ## Update the driver version
 
 rsw: workbench
 workbench:  ## Build Workbench image
-	DOCKER_BUILDKIT=1 docker build -t rstudio/rstudio-workbench:$(RSW_TAG_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSW_VERSION=$(RSW_VERSION) --file workbench/Dockerfile.bionic workbench
+	DOCKER_BUILDKIT=1 docker build -t rstudio/rstudio-workbench:$(RSW_TAG_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSW_VERSION=$(RSW_VERSION) --file workbench/Dockerfile.$(IMAGE_OS) workbench
 
 test-rsw: test-workbench
 test-workbench:
@@ -88,7 +90,7 @@ run-workbench:  ## Run RSW container
 
 rsc: connect
 connect:  ## Build RSC image
-	DOCKER_BUILDKIT=1 docker build -t rstudio/rstudio-connect:$(RSC_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSC_VERSION=$(RSC_VERSION) --file connect/Dockerfile.bionic connect
+	DOCKER_BUILDKIT=1 docker build -t rstudio/rstudio-connect:$(RSC_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSC_VERSION=$(RSC_VERSION) --file connect/Dockerfile.$(IMAGE_OS) connect
 
 test-rsc: test-connect
 test-connect:
@@ -112,7 +114,7 @@ run-connect:  ## Run RSC container
 
 rspm: package-manager
 package-manager:  ## Build RSPM image
-	DOCKER_BUILDKIT=1 docker build -t rstudio/rstudio-package-manager:$(RSPM_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSPM_VERSION=$(RSPM_VERSION) --file package-manager/Dockerfile.bionic package-manager
+	DOCKER_BUILDKIT=1 docker build -t rstudio/rstudio-package-manager:$(RSPM_VERSION) --build-arg R_VERSION=$(R_VERSION) --build-arg RSPM_VERSION=$(RSPM_VERSION) --file package-manager/Dockerfile.$(IMAGE_OS) package-manager
 
 
 test-rspm: test-package-manager

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ To build RStudio Package Manager:
 make package-manager
 ```
 
-You can alter what exactly is built by changing `workbench/Dockerfile`, `connect/Dockerfile`,
-and `package-manager/Dockerfile`.
+You can alter what exactly is built by changing `workbench/Dockerfile.$OS`, `connect/Dockerfile.$OS`,
+and `package-manager/Dockerfile.$OS`.
 
 You can then run what you've built to test out with the `run-` commands. For instance, to run the workbench container
 you have built:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: rstudio-workbench
     build:
       context: ./workbench
+      dockerfile: Dockerfile.bionic
       args:
         RSW_VERSION: 2022.07.1+554.pro3
     image: rstudio/rstudio-workbench:2022.07.1-554.pro3
@@ -22,6 +23,7 @@ services:
     container_name: rstudio-connect
     build:
       context: ./connect
+      dockerfile: Dockerfile.bionic
       args:
         RSC_VERSION: 2022.08.0
     image: rstudio/rstudio-connect:2022.08.0
@@ -39,6 +41,7 @@ services:
     container_name: rstudio-package-manager
     build:
       context: ./package-manager
+      dockerfile: Dockerfile.bionic
       args:
         RSPM_VERSION: 2022.07.2-11
     image: rstudio/rstudio-package-manager:2022.07.2-11

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: rstudio-workbench
     build:
       context: ./workbench
-      dockerfile: Dockerfile.bionic
+      dockerfile: "Dockerfile.${IMAGE_OS:-bionic}"
       args:
         RSW_VERSION: 2022.07.1+554.pro3
     image: rstudio/rstudio-workbench:2022.07.1-554.pro3
@@ -23,7 +23,7 @@ services:
     container_name: rstudio-connect
     build:
       context: ./connect
-      dockerfile: Dockerfile.bionic
+      dockerfile: "Dockerfile.${IMAGE_OS:-bionic}"
       args:
         RSC_VERSION: 2022.08.0
     image: rstudio/rstudio-connect:2022.08.0
@@ -41,7 +41,7 @@ services:
     container_name: rstudio-package-manager
     build:
       context: ./package-manager
-      dockerfile: Dockerfile.bionic
+      dockerfile: "Dockerfile.${IMAGE_OS:-bionic}"
       args:
         RSPM_VERSION: 2022.07.2-11
     image: rstudio/rstudio-package-manager:2022.07.2-11

--- a/float/docker-compose.yml
+++ b/float/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: rstudio/rstudio-workbench-float-lic
     build:
       context: ./
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.focal
       args:
         - "PRODUCT=rsp"
         - "PORT=8989"
@@ -22,7 +22,7 @@ services:
     image: rstudio/rstudio-connect-float-lic
     build:
       context: ./
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.focal
       args:
         - "PRODUCT=connect"
         - "PORT=8999"
@@ -38,7 +38,7 @@ services:
     image: rstudio/rstudio-package-manager-float-lic
     build:
       context: ./
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.focal
       args:
         - "PRODUCT=rspm"
         - "PORT=8969"


### PR DESCRIPTION
We recently changed our Dockerfile names to Dockerfile.bionic in preparation for additional OS support, but we did not update the Makefile and docker-compose Dockerfile targets to match this change. This PR updates all relevant places where the Dockerfile.bionic file must be specified. It also allows us to dynamically set the IMAGE_OS in the Makefile and main docker-compose.yml file. I also changed each build command to use `DOCKER_BUILDKIT=1` by default.