### PR TITLE
fix an issue where the `r-session-complete` image name is computed incorrectly

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -85,28 +85,35 @@ build-release $PRODUCT $OS $VERSION $BRANCH=`git branch --show` $SHA_SHORT=`git 
     SHORT_NAME="RSPM"
   fi
 
+  # set image prefix
+  if [[ $PRODUCT == "r-session-complete" ]]; then
+    IMAGE_PREFIX=""
+  else
+    IMAGE_PREFIX="rstudio-"
+  fi
+
   # set buildx args
   if [[ "{{BUILDX_PATH}}" != "" ]]; then
     BUILDX_ARGS="--cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache"
   fi
 
   docker buildx --builder="{{BUILDX_PATH}}" build --load $BUILDX_ARGS \
-        -t rstudio/rstudio-"$PRODUCT":"$OS" \
-        -t rstudio/rstudio-"$PRODUCT":"$OS"-"$TAG_VERSION" \
-        -t rstudio/rstudio-"$PRODUCT":"$OS"-"$TAG_VERSION"--"$SHA_SHORT" \
-        -t ghcr.io/rstudio/rstudio-"$PRODUCT":"$OS" \
-        -t ghcr.io/rstudio/rstudio-"$PRODUCT":"$OS"-"$TAG_VERSION" \
-        -t ghcr.io/rstudio/rstudio-"$PRODUCT":"$OS"-"$TAG_VERSION"--"$SHA_SHORT" \
+        -t rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS} \
+        -t rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS}-${TAG_VERSION} \
+        -t rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS}-${TAG_VERSION}--${SHA_SHORT} \
+        -t ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS} \
+        -t ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS}-${TAG_VERSION} \
+        -t ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS}-${TAG_VERSION}--${SHA_SHORT} \
         --build-arg "$SHORT_NAME"_VERSION=$VERSION \
         --build-arg RSW_DOWNLOAD_URL=$RSW_DOWNLOAD_URL \
-        --file=./"$PRODUCT"/Dockerfile."$OS" "$PRODUCT"
+        --file=./${PRODUCT}/Dockerfile.${OS} ${PRODUCT}
 
-  echo rstudio/rstudio-"$PRODUCT":"$OS" \
-        rstudio/rstudio-"$PRODUCT":"$OS"-"$TAG_VERSION" \
-        rstudio/rstudio-"$PRODUCT":"$OS"-"$TAG_VERSION"--"$SHA_SHORT" \
-        ghcr.io/rstudio/rstudio-"$PRODUCT":"$OS" \
-        ghcr.io/rstudio/rstudio-"$PRODUCT":"$OS"-"$TAG_VERSION" \
-        ghcr.io/rstudio/rstudio-"$PRODUCT":"$OS"-"$TAG_VERSION"--"$SHA_SHORT"
+  echo rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS} \
+        rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS}-${TAG_VERSION} \
+        rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS}-${TAG_VERSION}--${SHA_SHORT} \
+        ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS} \
+        ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS}-${TAG_VERSION} \
+        ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}:${OS}-${TAG_VERSION}--${SHA_SHORT}
 
 # just BUILDX_PATH=~/.buildx build-preview preview workbench bionic 12.0.11-11
 build-preview $TYPE $PRODUCT $OS $VERSION $BRANCH=`git branch --show`:
@@ -136,25 +143,32 @@ build-preview $TYPE $PRODUCT $OS $VERSION $BRANCH=`git branch --show`:
     SHORT_NAME="RSPM"
   fi
 
+  # set image prefix
+  if [[ $PRODUCT == "r-session-complete" ]]; then
+    IMAGE_PREFIX=""
+  else
+    IMAGE_PREFIX="rstudio-"
+  fi
+
   # set buildx args
   if [[ "{{BUILDX_PATH}}" != "" ]]; then
     BUILDX_ARGS="--cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache"
   fi
 
   docker buildx --builder="{{BUILDX_PATH}}" build --load $BUILDX_ARGS \
-        -t rstudio/rstudio-"$PRODUCT"-preview:"${BRANCH_PREFIX}${OS}"-"$TAG_VERSION" \
-        -t rstudio/rstudio-"$PRODUCT"-preview:"${BRANCH_PREFIX}${OS}"-"$TYPE" \
-        -t ghcr.io/rstudio/rstudio-"$PRODUCT"-preview:"${BRANCH_PREFIX}${OS}"-"$TAG_VERSION" \
-        -t ghcr.io/rstudio/rstudio-"$PRODUCT"-preview:"${BRANCH_PREFIX}${OS}"-"$TYPE" \
-        --build-arg "$SHORT_NAME"_VERSION=$VERSION \
+        -t rstudio/${IMAGE_PREFIX}${PRODUCT}-preview:${BRANCH_PREFIX}${OS}-${TAG_VERSION} \
+        -t rstudio/${IMAGE_PREFIX}${PRODUCT}-preview:${BRANCH_PREFIX}${OS}-${TYPE} \
+        -t ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}-preview:${BRANCH_PREFIX}${OS}-${TAG_VERSION} \
+        -t ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}-preview:${BRANCH_PREFIX}${OS}-${TYPE} \
+        --build-arg ${SHORT_NAME}_VERSION=$VERSION \
         --build-arg RSW_DOWNLOAD_URL=$RSW_DOWNLOAD_URL \
-        --file=./"$PRODUCT"/Dockerfile."$OS" "$PRODUCT"
+        --file=./${PRODUCT}/Dockerfile.${OS} ${PRODUCT}
 
   # These tags are propogated forward to test-images and push-images in builds. It is important that these tags match the build tags above.
-  echo rstudio/rstudio-"${PRODUCT}"-preview:"${BRANCH_PREFIX}${OS}"-"${TAG_VERSION}" \
-        rstudio/rstudio-"${PRODUCT}"-preview:"${BRANCH_PREFIX}""${OS}"-"${TYPE}" \
-        ghcr.io/rstudio/rstudio-"${PRODUCT}"-preview:"${BRANCH_PREFIX}${OS}"-"${TAG_VERSION}" \
-        ghcr.io/rstudio/rstudio-"${PRODUCT}"-preview:"${BRANCH_PREFIX}${OS}"-"${TYPE}"
+  echo rstudio/${IMAGE_PREFIX}${PRODUCT}-preview:${BRANCH_PREFIX}${OS}-${TAG_VERSION} \
+        rstudio/${IMAGE_PREFIX}${PRODUCT}-preview:${BRANCH_PREFIX}${OS}-${TYPE} \
+        ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}-preview:${BRANCH_PREFIX}${OS}-${TAG_VERSION} \
+        ghcr.io/rstudio/${IMAGE_PREFIX}${PRODUCT}-preview:${BRANCH_PREFIX}${OS}-${TYPE}
 
 _rsw-download-url TYPE OS:
   #!/usr/bin/env bash


### PR DESCRIPTION
Most of our images have an `rstudio-` prefix. However, `r-session-complete` does not.
As a result, we create an `$IMAGE_PREFIX` variable to contain the conditional prefix. This
will also prove useful if/when we decide to change the image prefix for most images. We also
removed a lot of double quotes (") and opted for `${}` syntax instead.