### PR TITLE
change session installation order

### DIFF
--- a/r-session-complete/Dockerfile.bionic
+++ b/r-session-complete/Dockerfile.bionic
@@ -9,40 +9,6 @@ ARG PYTHON_VERSION=3.9.5
 ARG DRIVERS_VERSION=2021.10.0
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install RStudio Workbench session components -------------------------------#
-
-RUN apt-get update -y && \
-    apt-get install --no-install-recommends -y \
-    ca-certificates \
-    curl \
-    wget \
-    krb5-user \
-    libcurl4-gnutls-dev \
-    libssl1.0.0 \
-    libssl-dev \
-    libuser \
-    libuser1-dev \
-    libpq-dev \
-    rrdtool && \
-    rm -rf /var/lib/apt/lists/*
-
-ARG RSW_VERSION=2022.07.1+554.pro3
-ARG RSW_NAME=rstudio-workbench
-ARG RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/bionic/amd64
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update --fix-missing \
-    && apt-get install --no-install-recommends -y gdebi-core \
-    && RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
-    && curl -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb" \
-    && gdebi --non-interactive rstudio-workbench.deb \
-    && rm rstudio-workbench.deb \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /var/lib/rstudio-server/r-versions
-
-EXPOSE 8788/tcp
-
 # Install additional system packages ------------------------------------------#
 
 RUN apt-get update -y && \
@@ -112,6 +78,41 @@ RUN curl -O https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_$
     cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/bionic/latest")'
+
+# Install RStudio Workbench session components -------------------------------#
+
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    wget \
+    krb5-user \
+    libcurl4-gnutls-dev \
+    libssl1.0.0 \
+    libssl-dev \
+    libuser \
+    libuser1-dev \
+    libpq-dev \
+    rrdtool && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG RSW_VERSION=2022.07.1+554.pro3
+ARG RSW_NAME=rstudio-workbench
+ARG RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/bionic/amd64
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update --fix-missing \
+    && apt-get install --no-install-recommends -y gdebi-core \
+    && RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
+    && curl -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb" \
+    && gdebi --non-interactive rstudio-workbench.deb \
+    && rm rstudio-workbench.deb \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/rstudio-server/r-versions
+
+EXPOSE 8788/tcp
+
 
 # Locale configuration --------------------------------------------------------#
 

--- a/r-session-complete/Dockerfile.centos7
+++ b/r-session-complete/Dockerfile.centos7
@@ -8,30 +8,6 @@ ARG MINICONDA_VERSION=py37_4.8.3
 ARG PYTHON_VERSION=3.9.5
 ARG DRIVERS_VERSION=2021.10.0-1
 
-# Install RStudio Workbench session components -------------------------------#
-RUN yum update -y && \
-    yum install -y \
-    libcurl-devel \
-    libuser-devel \
-    openssl-devel \
-    postgresql-libs \
-    rrdtool && \
-    yum clean all
-
-ARG RSW_VERSION=2022.07.1+554.pro3
-ARG RSW_NAME=rstudio-workbench-rhel
-ARG RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/centos7/x86_64
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
-    && curl -o rstudio-workbench.rpm "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-x86_64.rpm" \
-    && yum install -y rstudio-workbench.rpm \
-    && rm rstudio-workbench.rpm \
-    && yum clean all \
-    && rm -rf /var/lib/rstudio-server/r-versions
-
-EXPOSE 8788/tcp
-
 # Install additional system packages ------------------------------------------#
 
 RUN yum update -y && \
@@ -107,6 +83,31 @@ RUN curl -O https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers-$
     cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/centos7/latest")'
+
+# Install RStudio Workbench session components -------------------------------#
+RUN yum update -y && \
+    yum install -y \
+    libcurl-devel \
+    libuser-devel \
+    openssl-devel \
+    postgresql-libs \
+    rrdtool && \
+    yum clean all
+
+ARG RSW_VERSION=2022.07.1+554.pro3
+ARG RSW_NAME=rstudio-workbench-rhel
+ARG RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/centos7/x86_64
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
+    && curl -o rstudio-workbench.rpm "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-x86_64.rpm" \
+    && yum install -y rstudio-workbench.rpm \
+    && rm rstudio-workbench.rpm \
+    && yum clean all \
+    && rm -rf /var/lib/rstudio-server/r-versions
+
+EXPOSE 8788/tcp
+
 
 # Locale configuration --------------------------------------------------------#
 

--- a/r-session-complete/NEWS.md
+++ b/r-session-complete/NEWS.md
@@ -1,3 +1,7 @@
+# 2022.09
+
+- Change session installation order. This should make the "core analytics packages" more reproducible
+
 # 2022.07.0
 
 - Add a `/usr/local/bin/jupyter` symlink


### PR DESCRIPTION
Installing Workbench last, so that R and Python versions are the "more immutable" parts of the image