### PR TITLE
fix a typo in the content-pro dockerfile build

### DIFF
--- a/content/pro/bionic/Dockerfile
+++ b/content/pro/bionic/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION
 ARG R_VERSION
-FROM rstudio/content-pro:r${R_VERSION}-py${PYTHON_VERSION}-bionic
+FROM rstudio/content-base:r${R_VERSION}-py${PYTHON_VERSION}-bionic
 
 MAINTAINER RStudio Docker <docker@rstudio.com>
 


### PR DESCRIPTION
We accidentally created a recursive reference from content-pro images to other content-pro images. The reference here should have been content-base.