### PR TITLE
Fix versioning for RHEL Pro Drivers

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -12,6 +12,7 @@ RSW_VERSION := "2022.07.2+576.pro12"
 RSC_TAG_SAFE_VERSION := replace(RSW_VERSION, "+", "-")
 
 DRIVERS_VERSION := "2021.10.0"
+DRIVERS_VERSION_RHEL := "2021.10.0-1"
 
 R_VERSION := "3.6.2"
 R_VERSION_ALT := "4.1.0"
@@ -146,6 +147,7 @@ update-drivers-versions:
   set -euxo pipefail
   sed {{ sed_vars }} "s/\"drivers\": \".[^\,\}]*\"/\"drivers\": \"{{ DRIVERS_VERSION }}\"/g" content/matrix.json
   sed {{ sed_vars }} "s/DRIVERS_VERSION=.*/DRIVERS_VERSION={{ DRIVERS_VERSION }}/g" workbench-for-microsoft-azure-ml/Dockerfile.bionic
+  sed {{ sed_vars }} "s/DRIVERS_VERSION=.*/DRIVERS_VERSION={{ DRIVERS_VERSION_RHEL }}/g" r-session-complete/Dockerfile.centos7
   sed {{ sed_vars }} "s/^DRIVERS_VERSION := .*/DRIVERS_VERSION := \"{{ DRIVERS_VERSION }}\"/g" \
     content/pro/Justfile \
     Justfile

--- a/r-session-complete/Justfile
+++ b/r-session-complete/Justfile
@@ -11,6 +11,7 @@ RSW_TAG_SAFE_VERSION := replace(RSW_VERSION, "+", "-")
 RSW_LICENSE := ""
 
 DRIVERS_VERSION := "2021.10.0"
+DRIVERS_VERSION_RHEL := "2021.10.0-1"
 
 R_VERSION := "4.1.0"
 R_VERSION_ALT := "3.6.2"
@@ -28,6 +29,12 @@ build OS=IMAGE_OS VERSION=RSW_VERSION +TAGS=DEFAULT_TAG:
   if [[ "{{BUILDX_PATH}}" != "" ]]; then
     BUILDX_ARGS="--cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache"
   fi
+  if [[ "{{ OS }}" == "centos7" ]]; then
+    _DRIVERS_VERSION="{{ DRIVERS_VERSION_RHEL }}"
+  else
+    _DRIVERS_VERSION="{{ DRIVERS_VERSION }}"
+  fi
+
   tag_array=()
   for TAG in {{TAGS}}
   do
@@ -37,7 +44,7 @@ build OS=IMAGE_OS VERSION=RSW_VERSION +TAGS=DEFAULT_TAG:
   docker buildx --builder="{{ BUILDX_PATH }}" build --load ${BUILDX_ARGS} \
     ${tag_array[@]} \
     --build-arg RSW_VERSION="{{ VERSION }}" \
-    --build-arg DRIVERS_VERSION="{{ DRIVERS_VERSION }}" \
+    --build-arg DRIVERS_VERSION="${_DRIVERS_VERSION}" \
     --build-arg R_VERSION="{{ R_VERSION }}" \
     --build-arg R_VERSION_ALT="{{ R_VERSION_ALT }}" \
     --build-arg PYTHON_VERSION="{{ PYTHON_VERSION }}" \


### PR DESCRIPTION
The RHEL version of the Pro Drivers is `2021.10.0-1` while the version for other OSes is `2021.10.0`. Prior to this change all Pro Drivers versioning was treated the same. This change adds a `DRIVERS_VERSION_RHEL` setting to the appropriate Justfiles to make sure that our centos7 images use the correct version.