### PR TITLE
Add `workflow_call` to preview action to specify product version

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -9,10 +9,18 @@ on:
       - dev
       - dev-rspm
   pull_request:
+  workflow_call:
+    inputs:
+      product:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
 
 name: build/test/push (preview)
 jobs:
-
+  if: ${{ inputs.product != '' || inputs.product == matrix.config.product }}
 
   build:
     runs-on: ubuntu-latest
@@ -61,7 +69,7 @@ jobs:
       - name: Get Version
         id: get-version
         run: |
-          VERSION=`just -f ci.Justfile get-version ${{ matrix.config.product }} --type=${{ matrix.config.type }} --local`
+          VERSION=`[[ ! -z ${{ inputs.version }} && echo ${{ inputs.version }} ]] || just -f ci.Justfile get-version ${{ matrix.config.product }} --type=${{ matrix.config.type }} --local`
           echo "::set-output name=VERSION::$VERSION"
 
       - name: Build Image


### PR DESCRIPTION
Our infrastructure using the public preview images to pull from and test changes. This is useful for two reasons:

1. We can specify build versions that may occur between the CRON runs
2. We can specify builds outside the latest, e.g. release candidates, to pin our test infra to during regression