### PR TITLE
allow PATH lookups to be skipped

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -71,6 +71,22 @@ This command generates a single YAML for the available `rstudio/content-pro` ima
 		rstudio/content-pro:r4.1.0-py3.9.2-bionic  > runtime.yaml
 ```
 
+The `NO_PATH_LOOKUPS` environment variable indicates that `PATH` is ignored
+when attempting to discover R, Python, and Quarto installations.
+
+```console
+NO_PATH_LOOKUPS=1 ./scripts/build-image.sh \
+    rstudio/content-pro:r3.1.3-py2.7.18-bionic > runtime.yaml
+```
+
+The `DEBUG` environment variable produces additional output about the image
+analysis.
+
+```console
+DEBUG=1 ./scripts/build-image.sh \
+    rstudio/content-pro:r3.1.3-py2.7.18-bionic > runtime.yaml
+```
+
 ## Build matrix
 
 The json defined in `matrix.json` is loaded by the Github Action to

--- a/content/scripts/build-image-yaml.sh
+++ b/content/scripts/build-image-yaml.sh
@@ -12,6 +12,9 @@
 #     ./scripts/build-image-yaml.sh rstudio/content-base:r4.0.5-py3.9.2-bionic
 #     ./scripts/build-image-yaml.sh rstudio/content-base:r3.6.3-py3.8.8-bionic rstudio/content-base:r4.1.0-py3.9.2-bionic
 #
+# Set NO_PATH_LOOKUPS to ignore PATH-based lookups:
+#     NO_PATH_LOOKUPS=1 ./scripts/build-image-yaml.sh rstudio/connect-content-images:kitchen-sink-ubuntu16.04
+#
 # Set DEBUG for debugging output:
 #     DEBUG=1 ./scripts/build-image-yaml.sh rstudio/connect-content-images:kitchen-sink-ubuntu16.04
 #
@@ -48,7 +51,8 @@ for IMAGE in ${IMAGES} ; do
     log "Analyzing: ${IMAGE}"
     log "------------------------------------------------------------"
     docker run --rm \
-           -e DEBUG=${DEBUG} \
+           -e DEBUG="${DEBUG}" \
+           -e NO_PATH_LOOKUPS="${NO_PATH_LOOKUPS}" \
            -v "${SCRIPTS}":/scripts \
            "${IMAGE}" \
            /scripts/examine-image.sh | sort -n | uniq > "${TMPFILE}"

--- a/content/scripts/examine-image.sh
+++ b/content/scripts/examine-image.sh
@@ -25,6 +25,9 @@
 #
 # Informational messages are printed to STDERR.
 #
+# Skip PATH lookups by setting the NO_PATH_LOOKUPS environment variable:
+# docker run -e NO_PATH_LOOKUPS=1 --rm -v $(pwd)/scripts:/scripts rstudio/connect-content-images:kitchen-sink-ubuntu1604 /scripts/examine-image.sh > runtime.yaml
+#
 # Run with additional debug tracing by setting the DEBUG environment variable:
 # docker run -e DEBUG=yes --rm -v $(pwd)/scripts:/scripts rstudio/connect-content-images:kitchen-sink-ubuntu1604 /scripts/examine-image.sh > runtime.yaml
 
@@ -109,10 +112,14 @@ done
 
 # Probe R in PATH only when no other R available.
 if [ ${R_FOUND} = 0 ] ; then
-    R_EXE=$(which R 2>/dev/null)
-    status=$?
-    if [ ${status} = 0 ] ; then
-        r_exe_probe "PATH" "${R_EXE}"
+    if [ -z "${NO_PATH_LOOKUPS}" ] ; then
+        R_EXE=$(which R 2>/dev/null)
+        status=$?
+        if [ ${status} = 0 ] ; then
+            r_exe_probe "PATH" "${R_EXE}"
+        fi
+    else
+        log "Ignoring PATH for R discovery."
     fi
 fi
 
@@ -160,20 +167,24 @@ done
 
 # Probe Python in PATH only when no other Python available.
 if [ ${PYTHON_FOUND} = 0 ] ; then
-    PYTHON_EXE=$(which python 2>/dev/null)
-    status=$?
-    if [ ${status} = 0 ] ; then
-        python_exe_probe "PATH" "${PYTHON_EXE}"
-    fi
-    PYTHON_EXE=$(which python2 2>/dev/null)
-    status=$?
-    if [ ${status} = 0 ] ; then
-        python_exe_probe "PATH" "${PYTHON_EXE}"
-    fi
-    PYTHON_EXE=$(which python3 2>/dev/null)
-    status=$?
-    if [ ${status} = 0 ] ; then
-        python_exe_probe "PATH" "${PYTHON_EXE}"
+    if [ -z "${NO_PATH_LOOKUPS}" ] ; then
+        PYTHON_EXE=$(which python 2>/dev/null)
+        status=$?
+        if [ ${status} = 0 ] ; then
+            python_exe_probe "PATH" "${PYTHON_EXE}"
+        fi
+        PYTHON_EXE=$(which python2 2>/dev/null)
+        status=$?
+        if [ ${status} = 0 ] ; then
+            python_exe_probe "PATH" "${PYTHON_EXE}"
+        fi
+        PYTHON_EXE=$(which python3 2>/dev/null)
+        status=$?
+        if [ ${status} = 0 ] ; then
+            python_exe_probe "PATH" "${PYTHON_EXE}"
+        fi
+    else
+        log "Ignoring PATH for Python discovery."
     fi
 fi
 
@@ -234,10 +245,14 @@ done
 
 # Probe Quarto in PATH only when no other quarto available.
 if [ ${QUARTO_FOUND} = 0 ] ; then
-    QUARTO_EXE=$(which quarto 2>/dev/null)
-    status=$?
-    if [ ${status} = 0 ] ; then
-        quarto_exe_probe "PATH" "${QUARTO_EXE}"
+    if [ -z "${NO_PATH_LOOKUPS}" ] ; then
+        QUARTO_EXE=$(which quarto 2>/dev/null)
+        status=$?
+        if [ ${status} = 0 ] ; then
+            quarto_exe_probe "PATH" "${QUARTO_EXE}"
+        fi
+    else
+        log "Ignoring PATH for R discovery."
     fi
 fi
 


### PR DESCRIPTION
Bypasses `PATH` probing for R, Python, and Quarto installations.

fixes #423