### PR TITLE
Fix broken regex for Python version updates

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -141,7 +141,7 @@ update-py-versions:
   #!/usr/bin/env bash
   set -euxo pipefail
   # Update primary Python versions
-  sed {{ sed_vars }} "s/PYTHON_VERSION=.*/PYTHON_VERSION={{ PYTHON_VERSION }}/g" \
+  sed {{ sed_vars }} "s/^PYTHON_VERSION=.*/PYTHON_VERSION={{ PYTHON_VERSION }}/g" \
     workbench/Dockerfile.ubuntu1804 \
     workbench/Dockerfile.ubuntu2204 \
     workbench/.env \
@@ -158,13 +158,14 @@ update-py-versions:
     Justfile
 
   # Update alt Python versions
-  sed {{ sed_vars }} "s/PYTHON_VERSION_ALT=.*/PYTHON_VERSION_ALT={{ PYTHON_VERSION_ALT }}/g" \
+  sed {{ sed_vars }} "s/^PYTHON_VERSION_ALT=.*/PYTHON_VERSION_ALT={{ PYTHON_VERSION_ALT }}/g" \
     workbench/Dockerfile.ubuntu1804 \
     workbench/Dockerfile.ubuntu2204 \
     workbench/.env \
     connect/Dockerfile.ubuntu1804 \
     connect/Dockerfile.ubuntu2204 \
-    connect/.env \
+    connect/.env
+  sed {{ sed_vars }} "s/^PYTHON_VERSION_ALT := .*/PYTHON_VERSION_ALT := \"{{ PYTHON_VERSION_ALT }}\"/g" \
     workbench/Justfile \
     workbench-for-microsoft-azure-ml/Justfile \
     connect/Justfile \

--- a/Justfile
+++ b/Justfile
@@ -105,7 +105,7 @@ update-r-versions:
   #!/usr/bin/env bash
   set -euxo pipefail
   # Update primary R versions
-  sed {{ sed_vars }} "s/R_VERSION=.*/R_VERSION={{ R_VERSION }}/g" \
+  sed {{ sed_vars }} "s/^R_VERSION=.*/R_VERSION={{ R_VERSION }}/g" \
     workbench/.env \
     connect/.env \
     package-manager/.env \
@@ -123,7 +123,7 @@ update-r-versions:
     Justfile
 
   # Update alt R versions
-  sed {{ sed_vars }} "s/R_VERSION_ALT=.*/R_VERSION_ALT={{ R_VERSION_ALT }}/g" \
+  sed {{ sed_vars }} "s/^R_VERSION_ALT=.*/R_VERSION_ALT={{ R_VERSION_ALT }}/g" \
     workbench/.env \
     connect/.env \
     workbench/Dockerfile.ubuntu1804 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: "Dockerfile.${IMAGE_OS:-ubuntu1804}"
       args:
         RSW_VERSION: 2022.07.2+576.pro12
-    image: rstudio/rstudio-workbench:2022.07.2-576.pro12
+    image: rstudio/rstudio-workbench:2022.07.2
     environment:
       RSW_LICENSE: ${RSW_LICENSE}
       LICENSE_SERVER: ${RSW_LICENSE_SERVER}
@@ -44,7 +44,7 @@ services:
       dockerfile: "Dockerfile.${IMAGE_OS:-ubuntu1804}"
       args:
         RSPM_VERSION: 2022.07.2-11
-    image: rstudio/rstudio-package-manager:2022.07.2-11
+    image: rstudio/rstudio-package-manager:2022.07.2
     environment:
       RSPM_LICENSE: ${RSPM_LICENSE}
       LICENSE_SERVER: ${RSPM_LICENSE_SERVER}

--- a/r-session-complete/Dockerfile.ubuntu2204
+++ b/r-session-complete/Dockerfile.ubuntu2204
@@ -24,7 +24,7 @@ RUN apt-get update -y && \
     rrdtool && \
     rm -rf /var/lib/apt/lists/*
 
-ARG RSW_VERSION=2022.07.1+554.pro3
+ARG RSW_VERSION=2022.07.2+576.pro12
 ARG RSW_NAME=rstudio-workbench
 ARG RSW_DOWNLOAD_URL=https://s3.amazonaws.com/rstudio-ide-build/server/jammy/amd64
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workbench-for-microsoft-azure-ml/.env
+++ b/workbench-for-microsoft-azure-ml/.env
@@ -1,4 +1,4 @@
-RSW_VERSION=2022.07.0+548.pro5
+RSW_VERSION=2022.07.2+576.pro12
 RSW_DOWNLOAD_URL=https://download2.rstudio.org/server/bionic/amd64
 RSW_NAME=rstudio-workbench
 PYTHON_VERSION=3.9.5

--- a/workbench/Dockerfile.ubuntu1804
+++ b/workbench/Dockerfile.ubuntu1804
@@ -53,7 +53,7 @@ RUN apt-get update -qq && \
 
 # Install jupyter -------------------------------------------------------------#
 
-ARG JUPYTER_VERSION=3.6.2
+ARG JUPYTER_VERSION=3.8.10
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/jupyter && \
     /opt/python/jupyter/bin/conda install -y python==${JUPYTER_VERSION} && \

--- a/workbench/Dockerfile.ubuntu1804
+++ b/workbench/Dockerfile.ubuntu1804
@@ -1,4 +1,4 @@
-ARG R_VERSION=3.6
+ARG R_VERSION=3.6.2
 FROM rstudio/r-base:${R_VERSION}-bionic
 LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 
@@ -53,7 +53,7 @@ RUN apt-get update -qq && \
 
 # Install jupyter -------------------------------------------------------------#
 
-ARG JUPYTER_VERSION=3.8.10
+ARG JUPYTER_VERSION=3.6.2
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/jupyter && \
     /opt/python/jupyter/bin/conda install -y python==${JUPYTER_VERSION} && \

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -1,4 +1,4 @@
-ARG R_VERSION=3.6
+ARG R_VERSION=3.6.2
 FROM rstudio/r-base:${R_VERSION}-jammy
 LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 
@@ -50,7 +50,7 @@ RUN apt-get update -qq && \
 
 # Install jupyter -------------------------------------------------------------#
 
-ARG JUPYTER_VERSION=3.8.10
+ARG JUPYTER_VERSION=3.6.2
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/jupyter && \
     /opt/python/jupyter/bin/conda install -y python==${JUPYTER_VERSION} && \
@@ -123,7 +123,7 @@ COPY supervisord.conf /etc/supervisor/supervisord.conf
 COPY --chmod=0775 startup.sh /usr/local/bin/startup.sh
 
 # Install RStudio Workbench --------------------------------------------------#
-ARG RSW_VERSION=2022.07.1+554.pro3
+ARG RSW_VERSION=2022.07.2+576.pro12
 ARG RSW_DOWNLOAD_URL=https://download2.rstudio.org/server/jammy/amd64
 ARG RSW_NAME=rstudio-workbench
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -50,7 +50,7 @@ RUN apt-get update -qq && \
 
 # Install jupyter -------------------------------------------------------------#
 
-ARG JUPYTER_VERSION=3.6.2
+ARG JUPYTER_VERSION=3.8.10
 RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -bp /opt/python/jupyter && \
     /opt/python/jupyter/bin/conda install -y python==${JUPYTER_VERSION} && \


### PR DESCRIPTION
Part of the `PYTHON_VERSION_ALT` version update regex got lost somewhere down the line. This readds the missing regex snippet and runs `just update-versions` to bring everything up to date.