### PR TITLE
Improve Snyk CLI scans

### DIFF
--- a/.github/workflows/build-content.yaml
+++ b/.github/workflows/build-content.yaml
@@ -73,7 +73,7 @@ jobs:
           docker image ls
 
       - name: Run Snyk to check Docker image for vulnerabilities (main)
-        #if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
@@ -84,7 +84,7 @@ jobs:
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
-        #if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.ref != 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:

--- a/.github/workflows/build-content.yaml
+++ b/.github/workflows/build-content.yaml
@@ -73,25 +73,37 @@ jobs:
           docker image ls
 
       - name: Run Snyk to check Docker image for vulnerabilities (main)
-        if: ${{ github.ref == 'refs/heads/main' }}
+        #if: ${{ github.ref == 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: --file=./content/base/Dockerfile.${{ matrix.config.os }}
+          args: |
+            --file=./content/base/Dockerfile.${{ matrix.config.os }} \
+            --org=${{ secrets.SNYK_ORG_ID }} \
+            --product-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} \
+            --tags=product=content-base,os=${{ matrix.config.os }} \
+            --app-vulns \
+            --exclude-base-image-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
-        if: ${{ github.ref != 'refs/heads/main' }}
+        #if: ${{ github.ref != 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: --file=./content/base/Dockerfile.${{ matrix.config.os }}
+          args: |
+            --file=./content/base/Dockerfile.${{ matrix.config.os }} \
+            --org=${{ secrets.SNYK_ORG_ID }} \
+            --product-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} \
+            --tags=product=content-base,os=${{ matrix.config.os }} \
+            --app-vulns \
+            --exclude-base-image-vulns
           command: test
 
       - name: Login to Docker Hub
@@ -174,25 +186,37 @@ jobs:
           docker image ls
 
       - name: Run Snyk to check Docker image for vulnerabilities (main)
-        if: ${{ github.ref == 'refs/heads/main' }}
+        #if: ${{ github.ref == 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: --file=./content/pro/${{ matrix.config.os }}/Dockerfile
+          args: |
+            --file=./content/pro/${{ matrix.config.os }}/Dockerfile \
+            --org=${{ secrets.SNYK_ORG_ID }} \
+            --product-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} \
+            --tags=product=content-pro,os=${{ matrix.config.os }} \
+            --app-vulns \
+            --exclude-base-image-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
-        if: ${{ github.ref != 'refs/heads/main' }}
+        #if: ${{ github.ref != 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: --file=./content/pro/${{ matrix.config.os }}/Dockerfile
+          args: |
+            --file=./content/pro/${{ matrix.config.os }}/Dockerfile \
+            --org=${{ secrets.SNYK_ORG_ID }} \
+            --product-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} \
+            --tags=product=content-pro,os=${{ matrix.config.os }} \
+            --app-vulns \
+            --exclude-base-image-vulns
           command: test
 
       - name: Login to Docker Hub

--- a/.github/workflows/build-content.yaml
+++ b/.github/workflows/build-content.yaml
@@ -174,7 +174,7 @@ jobs:
           docker image ls
 
       - name: Run Snyk to check Docker image for vulnerabilities (main)
-        #if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
@@ -185,7 +185,7 @@ jobs:
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
-        #if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.ref != 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:

--- a/.github/workflows/build-content.yaml
+++ b/.github/workflows/build-content.yaml
@@ -80,7 +80,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: --file=./content/base/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-base,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
+          args: --file=./content/base/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --project-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-base,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
@@ -91,7 +91,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: --file=./content/base/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-base,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
+          args: --file=./content/base/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --project-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-base,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
           command: test
 
       - name: Login to Docker Hub
@@ -181,7 +181,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: --file=./content/pro/${{ matrix.config.os }}/Dockerfile --org=${{ secrets.SNYK_ORG_ID }} --product-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-pro,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
+          args: --file=./content/pro/${{ matrix.config.os }}/Dockerfile --org=${{ secrets.SNYK_ORG_ID }} --project-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-pro,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
@@ -192,7 +192,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: --file=./content/pro/${{ matrix.config.os }}/Dockerfile --org=${{ secrets.SNYK_ORG_ID }} --product-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-pro,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
+          args: --file=./content/pro/${{ matrix.config.os }}/Dockerfile --org=${{ secrets.SNYK_ORG_ID }} --project-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-pro,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
           command: test
 
       - name: Login to Docker Hub

--- a/.github/workflows/build-content.yaml
+++ b/.github/workflows/build-content.yaml
@@ -80,13 +80,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: |
-            --file=./content/base/Dockerfile.${{ matrix.config.os }} \
-            --org=${{ secrets.SNYK_ORG_ID }} \
-            --product-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} \
-            --tags=product=content-base,os=${{ matrix.config.os }} \
-            --app-vulns \
-            --exclude-base-image-vulns
+          args: --file=./content/base/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-base,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
@@ -97,13 +91,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: |
-            --file=./content/base/Dockerfile.${{ matrix.config.os }} \
-            --org=${{ secrets.SNYK_ORG_ID }} \
-            --product-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} \
-            --tags=product=content-base,os=${{ matrix.config.os }} \
-            --app-vulns \
-            --exclude-base-image-vulns
+          args: --file=./content/base/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=rstudio/content-base:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-base,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
           command: test
 
       - name: Login to Docker Hub
@@ -193,13 +181,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: |
-            --file=./content/pro/${{ matrix.config.os }}/Dockerfile \
-            --org=${{ secrets.SNYK_ORG_ID }} \
-            --product-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} \
-            --tags=product=content-pro,os=${{ matrix.config.os }} \
-            --app-vulns \
-            --exclude-base-image-vulns
+          args: --file=./content/pro/${{ matrix.config.os }}/Dockerfile --org=${{ secrets.SNYK_ORG_ID }} --product-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-pro,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
@@ -210,13 +192,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }}
-          args: |
-            --file=./content/pro/${{ matrix.config.os }}/Dockerfile \
-            --org=${{ secrets.SNYK_ORG_ID }} \
-            --product-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} \
-            --tags=product=content-pro,os=${{ matrix.config.os }} \
-            --app-vulns \
-            --exclude-base-image-vulns
+          args: --file=./content/pro/${{ matrix.config.os }}/Dockerfile --org=${{ secrets.SNYK_ORG_ID }} --product-name=rstudio/content-pro:r${{ matrix.config.r }}-py${{ matrix.config.py }}-${{ matrix.config.os }} --tags=product=content-pro,os=${{ matrix.config.os }} --app-vulns --exclude-base-image-vulns
           command: test
 
       - name: Login to Docker Hub

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -85,7 +85,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: ${{ steps.build-image.outputs.TAGS }}
+          image: ${{ steps.get-default-tag.outputs.DEFAULT_TAG }}
           args: |
             --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} \
             --org=${{ secrets.SNYK_ORG_ID }} \
@@ -102,7 +102,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          image: ${{ steps.build-image.outputs.TAGS }}
+          image: ${{ steps.get-default-tag.outputs.DEFAULT_TAG }}
           args: |
             --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} \
             --org=${{ secrets.SNYK_ORG_ID }} \

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -86,7 +86,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ steps.get-default-tag.outputs.DEFAULT_TAG }}
-          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns
+          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns --app-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
@@ -97,7 +97,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ steps.get-default-tag.outputs.DEFAULT_TAG }}
-          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns
+          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns --app-vulns
           command: test
 
       - name: Login to Docker Hub

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -79,7 +79,7 @@ jobs:
           just test-image ${{ matrix.config.product }} ${{  steps.get-version.outputs.VERSION }} ${{ steps.build-image.outputs.TAGS }}
 
       - name: Run Snyk to check Docker image for vulnerabilities (main)
-        #if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
@@ -90,7 +90,7 @@ jobs:
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
-        #if: ${{ github.ref != 'refs/heads/main' }}
+        if: ${{ github.ref != 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -86,12 +86,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ steps.get-default-tag.outputs.DEFAULT_TAG }}
-          args: |
-            --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} \
-            --org=${{ secrets.SNYK_ORG_ID }} \
-            --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} \
-            --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} \
-            --exclude-base-image-vulns
+          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
@@ -102,12 +97,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ steps.get-default-tag.outputs.DEFAULT_TAG }}
-          args: |
-            --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} \
-            --org=${{ secrets.SNYK_ORG_ID }} \
-            --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} \
-            --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} \
-            --exclude-base-image-vulns
+          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns
           command: test
 
       - name: Login to Docker Hub

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -86,7 +86,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ steps.get-default-tag.outputs.DEFAULT_TAG }}
-          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns --app-vulns
+          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --project-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns --app-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
@@ -97,7 +97,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ steps.get-default-tag.outputs.DEFAULT_TAG }}
-          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns --app-vulns
+          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} --org=${{ secrets.SNYK_ORG_ID }} --project-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} --exclude-base-image-vulns --app-vulns
           command: test
 
       - name: Login to Docker Hub

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -91,7 +91,6 @@ jobs:
             --org=${{ secrets.SNYK_ORG_ID }} \
             --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} \
             --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} \
-            --app-vulns \
             --exclude-base-image-vulns
           command: monitor
 
@@ -108,7 +107,6 @@ jobs:
             --org=${{ secrets.SNYK_ORG_ID }} \
             --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} \
             --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} \
-            --app-vulns \
             --exclude-base-image-vulns
           command: test
 

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -54,6 +54,12 @@ jobs:
           VERSION=`just -f ci.Justfile get-version ${{ matrix.config.product }} --type=release --local`
           echo "::set-output name=VERSION::$VERSION"
 
+      - name: Get default tag
+        id: get-default-tag
+        run: |
+          DEFAULT_TAG=`just -f ci.Justfile _get-default-tag ${{ matrix.config.product }} ${{ matrix.config.os }}`
+          echo "::set-output name=DEFAULT_TAG::$DEFAULT_TAG"
+
       - name: Build Image
         id: build-image
         run: |
@@ -73,25 +79,37 @@ jobs:
           just test-image ${{ matrix.config.product }} ${{  steps.get-version.outputs.VERSION }} ${{ steps.build-image.outputs.TAGS }}
 
       - name: Run Snyk to check Docker image for vulnerabilities (main)
-        if: ${{ github.ref == 'refs/heads/main' }}
+        #if: ${{ github.ref == 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ steps.build-image.outputs.TAGS }}
-          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }}
+          args: |
+            --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} \
+            --org=${{ secrets.SNYK_ORG_ID }} \
+            --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} \
+            --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} \
+            --app-vulns \
+            --exclude-base-image-vulns
           command: monitor
 
       - name: Run Snyk to check Docker image for vulnerabilities (branch)
-        if: ${{ github.ref != 'refs/heads/main' }}
+        #if: ${{ github.ref != 'refs/heads/main' }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ steps.build-image.outputs.TAGS }}
-          args: --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }}
+          args: |
+            --file=./${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }} \
+            --org=${{ secrets.SNYK_ORG_ID }} \
+            --product-name=${{ steps.get-default-tag.outputs.DEFAULT_TAG }} \
+            --tags=product=${{ matrix.config.product }},os=${{ matrix.config.os }} \
+            --app-vulns \
+            --exclude-base-image-vulns
           command: test
 
       - name: Login to Docker Hub

--- a/ci.Justfile
+++ b/ci.Justfile
@@ -1,6 +1,7 @@
 set positional-arguments
 
 BUILDX_PATH := ""
+REGISTRY_NAMESPACE := "rstudio"
 
 _get-os-alias OS:
   #!/usr/bin/env bash
@@ -11,6 +12,19 @@ _get-os-alias OS:
   else
     echo "{{OS}}"
   fi
+
+_get-default-tag PRODUCT OS:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+
+  # set image prefix
+  if [[ {{ PRODUCT }} == "r-session-complete" ]]; then
+    IMAGE_PREFIX=""
+  else
+    IMAGE_PREFIX="rstudio-"
+  fi
+
+  echo "{{ REGISTRY_NAMESPACE }}/${IMAGE_PREFIX}{{ PRODUCT }}:{{ OS }}"
 
 # just BUILDX_PATH=~/.buildx build-release workbench ubuntu1804 12.0.11-11
 build-release $PRODUCT $OS $VERSION $BRANCH=`git branch --show` $SHA_SHORT=`git rev-parse --short HEAD`:


### PR DESCRIPTION
After adding the Ubuntu 22.04 image versions, the CLI Snyk scans we were doing encountered a race condition where whatever product's OS we scanned last is what was presented in Snyk instead of all the OS versions. This change adds options to ensure all OS versions of images are tracked individually in Snyk in addition to enabling additional features such as app content scanning.