### PR TITLE
Authenticate `setup-just` actions

### DIFF
--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Set up Just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
@@ -108,6 +110,8 @@ jobs:
 
       - name: Set up Just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
@@ -205,6 +209,8 @@ jobs:
 
       - name: Set up Just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Set up Just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Set up Just
         uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx


### PR DESCRIPTION
Closes #451

We're one of the fringe cases noted in the [`setup-just` examples](https://github.com/extractions/setup-just#examples) that needs to authenticate our `setup-just` action calls. This PR adds the `GITHUB_TOKEN` env to our calls to prevent getting ratelimited.