### PR TITLE
Update deprecated `set-output` commands to use `>> $GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/build-content.yaml
+++ b/.github/workflows/build-content.yaml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: set-matrix
         run: |
           MATRIX=$(jq -Mcr < content/matrix.json)
@@ -31,14 +31,14 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./content/base
           file: ./content/base/Dockerfile.${{ matrix.config.os }}
@@ -96,14 +96,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -131,13 +131,13 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./content/pro
           file: ./content/pro/Dockerfile.${{ matrix.config.os }}
@@ -197,14 +197,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-content.yaml
+++ b/.github/workflows/build-content.yaml
@@ -17,7 +17,7 @@ jobs:
       - id: set-matrix
         run: |
           MATRIX=$(jq -Mcr < content/matrix.json)
-          echo "::set-output name=matrix::$MATRIX"
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Just
         uses: extractions/setup-just@v1
@@ -27,10 +27,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -75,14 +75,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
         #if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Just
         uses: extractions/setup-just@v1
@@ -115,10 +115,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -126,7 +126,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -170,7 +170,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -205,7 +205,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Just
         uses: extractions/setup-just@v1
@@ -214,10 +214,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -225,7 +225,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -285,7 +285,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -88,7 +88,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.BUILD_PAT }}
 
-      - name: Push image(s) to Docker Hub
+      - name: Push image(s) to registries
         #if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           just -f ci.Justfile push-images ${{ steps.build-base-image.outputs.TAGS }}
@@ -175,7 +175,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Push image(s) to Docker Hub
+      - name: Push image(s) to registries
         #if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           just -f ci.Justfile push-images ${{ steps.build-pro-image.outputs.TAGS }}
@@ -290,7 +290,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Push image(s) to Docker Hub
+      - name: Push image(s) to registries
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           just -f ci.Justfile push-images ${{ steps.build-image.outputs.TAGS }}

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -41,7 +41,7 @@ jobs:
         id: build-base-image
         run: |
           TAGS=`just -f ci.Justfile BUILDX_PATH=${{ steps.buildx.outputs.name }} build-base ${{ matrix.os }} base`
-          echo "::set-output name=TAGS::$TAGS"
+          echo "TAGS=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Show image size
         run: |
@@ -136,7 +136,7 @@ jobs:
         id: build-pro-image
         run: |
           TAGS=`just -f ci.Justfile BUILDX_PATH=${{ steps.buildx.outputs.name }} build-base ${{ matrix.os }} pro`
-          echo "::set-output name=TAGS::$TAGS"
+          echo "TAGS=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Show image size
         run: |
@@ -235,19 +235,19 @@ jobs:
         id: get-version
         run: |
           VERSION=`just -f ci.Justfile get-version ${{ matrix.config.product }} --type=release --local`
-          echo "::set-output name=VERSION::$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Get default tag
         id: get-default-tag
         run: |
           DEFAULT_TAG=`just -f ci.Justfile _get-default-tag ${{ matrix.config.product }} ${{ matrix.config.os }}`
-          echo "::set-output name=DEFAULT_TAG::$DEFAULT_TAG"
+          echo "DEFAULT_TAG=$DEFAULT_TAG" >> $GITHUB_OUTPUT
 
       - name: Build Image
         id: build-image
         run: |
           TAGS=`just -f ci.Justfile BUILDX_PATH=${{ steps.buildx.outputs.name }} build-release ${{ matrix.config.product }} ${{ matrix.config.os }} ${{ steps.get-version.outputs.VERSION }}`
-          echo "::set-output name=TAGS::$TAGS"
+          echo "TAGS=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Show image size
         run: |

--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -52,13 +52,13 @@ jobs:
         id: get-version
         run: |
           VERSION=`just -f ci.Justfile get-version ${{ github.event.inputs.product }} --type=${{ github.event.inputs.type }} --local --override=${{ github.event.inputs.version }}`
-          echo "::set-output name=VERSION::$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build Image
         id: build-image
         run: |
           TAGS=`just -f ci.Justfile BUILDX_PATH=${{ steps.buildx.outputs.name }} build-preview ${{ github.event.inputs.type }} ${{ github.event.inputs.product }} ${{ github.event.inputs.os }} ${{ steps.get-version.outputs.VERSION }}`
-          echo "::set-output name=TAGS::$TAGS"
+          echo "TAGS=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Show image size
         run: |

--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Just
         uses: extractions/setup-just@v1
@@ -38,10 +38,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -74,14 +74,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -87,7 +87,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.BUILD_PAT }}
 
-      - name: Push image(s) to Docker Hub
+      - name: Push image(s) to registries
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
         run: |
           just -f ci.Justfile push-images ${{ steps.build-image.outputs.TAGS }}

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -99,7 +99,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.BUILD_PAT }}
 
-      - name: Push image(s) to Docker Hub
+      - name: Push image(s) to registries
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
         run: |
           just -f ci.Justfile push-images ${{ steps.build-image.outputs.TAGS }}

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -64,13 +64,13 @@ jobs:
         id: get-version
         run: |
           VERSION=`just -f ci.Justfile get-version ${{ matrix.config.product }} --type=${{ matrix.config.type }} --local`
-          echo "::set-output name=VERSION::$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build Image
         id: build-image
         run: |
           TAGS=`just -f ci.Justfile BUILDX_PATH=${{ steps.buildx.outputs.name }} build-preview ${{ matrix.config.type }} ${{ matrix.config.product }} ${{ matrix.config.os }} ${{ steps.get-version.outputs.VERSION }}`
-          echo "::set-output name=TAGS::$TAGS"
+          echo "TAGS=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Show image size
         run: |

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Just
         uses: extractions/setup-just@v1
@@ -50,10 +50,10 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -86,14 +86,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
         if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/dev-rspm' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/clean-registry.yaml
+++ b/.github/workflows/clean-registry.yaml
@@ -14,7 +14,7 @@ jobs:
     name: cleanup-dockerhub
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Script
         run: ./tools/dockerhub_clean.py

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Hadolint
-        uses: hadolint/hadolint-action@v2.0.0
+        uses: hadolint/hadolint-action@v3.0.0
         with:
           dockerfile: ${{ matrix.config.product }}/Dockerfile.${{ matrix.config.os }}
           config: ./hadolint.yaml

--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3.1.2


### PR DESCRIPTION
Closes #418 

Github is changing the way their workflow export functions work and are therefore deprecating functions we currently use like `set-output`. This PR updates all uses of `set-output` to `>> $GITHUB_OUTPUT`.