### PR TITLE
prospective fix builds by downgrading just

### DIFF
--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -24,6 +24,8 @@ jobs:
         uses: extractions/setup-just@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          just-version: '1.11.0'
 
       - name: Set up Docker Buildx
         id: buildx
@@ -112,6 +114,8 @@ jobs:
         uses: extractions/setup-just@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          just-version: '1.11.0'
 
       - name: Set up Docker Buildx
         id: buildx
@@ -211,6 +215,8 @@ jobs:
         uses: extractions/setup-just@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          just-version: '1.11.0'
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/build-preview-webhook.yaml
+++ b/.github/workflows/build-preview-webhook.yaml
@@ -35,6 +35,8 @@ jobs:
         uses: extractions/setup-just@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          just-version: '1.11.0'
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -47,6 +47,8 @@ jobs:
         uses: extractions/setup-just@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          just-version: '1.11.0'
 
       - name: Set up Docker Buildx
         id: buildx


### PR DESCRIPTION
It seems that a new version of just has broken our build pipeline because `just path/target some/other` gets misinterpreted to mean multiple paths were provided.