### PR TITLE
Removes prefix from 'content-base' and 'content-pro'

### DIFF
--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -20,8 +20,8 @@ jobs:
           - {prefix: 'rstudio-', repository: 'workbench', readme_path: './workbench/README.md'}
           - {prefix: 'rstudio-', repository: 'connect', readme_path: './connect/README.md'}
           - {prefix: 'rstudio-', repository: 'connect-content-init', readme_path: './connect-content-init/README.md'}
-          - {prefix: 'rstudio-', repository: 'content-base', readme_path: './content/base/README.md'}
-          - {prefix: 'rstudio-', repository: 'content-pro', readme_path: './content/pro/README.md'}
+          - {prefix: '', repository: 'content-base', readme_path: './content/base/README.md'}
+          - {prefix: '', repository: 'content-pro', readme_path: './content/pro/README.md'}
           - {prefix: 'rstudio-', repository: 'package-manager', readme_path: './package-manager/README.md'}
           - {prefix: '', repository: 'r-session-complete', readme_path: './r-session-complete/README.md'}
           - {prefix: 'rstudio-', repository: 'workbench-for-microsoft-azure-ml', readme_path: './workbench-for-microsoft-azure-ml/README.md'}


### PR DESCRIPTION
The prefix does not exists for 'content-base' and 'content-pro'.

- https://hub.docker.com/repository/docker/rstudio/content-base/general
- https://hub.docker.com/repository/docker/rstudio/content-pro/general