### PR TITLE
Add python to the PATH variable in r-session-complete

### DIFF
--- a/r-session-complete/Dockerfile.centos7
+++ b/r-session-complete/Dockerfile.centos7
@@ -39,7 +39,7 @@ RUN /opt/python/"${PYTHON_VERSION}"/bin/pip3 install \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter \
-    && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter \
+    && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
 ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 

--- a/r-session-complete/Dockerfile.centos7
+++ b/r-session-complete/Dockerfile.centos7
@@ -39,7 +39,9 @@ RUN /opt/python/"${PYTHON_VERSION}"/bin/pip3 install \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter \
-    && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+    && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter \
+
+ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 
 COPY vscode.extensions.conf /etc/rstudio/vscode.extensions.conf
 

--- a/r-session-complete/Dockerfile.ubuntu1804
+++ b/r-session-complete/Dockerfile.ubuntu1804
@@ -52,6 +52,8 @@ RUN /opt/python/"${PYTHON_VERSION}"/bin/pip install \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
+ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
+
 COPY vscode.extensions.conf /etc/rstudio/vscode.extensions.conf
 
 EXPOSE 8788/tcp

--- a/r-session-complete/Dockerfile.ubuntu2204
+++ b/r-session-complete/Dockerfile.ubuntu2204
@@ -52,6 +52,8 @@ RUN /opt/python/"${PYTHON_VERSION}"/bin/pip install \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter \
     && /opt/python/"${PYTHON_VERSION}"/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
+ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
+
 COPY vscode.extensions.conf /etc/rstudio/vscode.extensions.conf
 
 EXPOSE 8788/tcp

--- a/r-session-complete/test/goss.yaml
+++ b/r-session-complete/test/goss.yaml
@@ -34,3 +34,14 @@ command:
     stdout: [
       "{{ .Env.PYTHON_VERSION }}"
     ]
+
+  "python3 --version":
+    title: python_in_path_var
+    exit-status: 0
+    stdout: [
+      "{{ .Env.PYTHON_VERSION }}"
+    ]
+
+  "jupyter --version":
+    title: jupyter_in_path_var
+    exit-status: 0


### PR DESCRIPTION
Closes #481 

I've noticed this issue crop up a few times in the last week with both internal teams and a customer. I prepended the `/opt/python/${PYTHON_VERSION}/bin` path to the `PATH` variable in the container to make it more immediately accessible to users.