### PR TITLE
Dynamically generate the Workbench Justfile download url

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -40,6 +40,17 @@ _parse-os OS:
     echo "{{OS}}"
   fi
 
+# just _rev-parse-os ubuntu1804
+_rev-parse-os OS:
+  #!/usr/bin/env bash
+  if [[ "{{OS}}" == "ubuntu1804" ]]; then
+    echo "bionic"
+  elif [[ "{{OS}}" == "ubuntu2204" ]]; then
+    echo "jammy"
+  else
+    echo "{{OS}}"
+  fi
+
 # just
 _config-license-persist-volumes TYPE PRODUCT HOST_DIR:
   #!/usr/bin/env bash

--- a/workbench/Justfile
+++ b/workbench/Justfile
@@ -8,7 +8,6 @@ IMAGE_OS := "ubuntu1804"
 
 RSW_VERSION := "2022.12.0+353.pro20"
 RSW_LICENSE := ""
-RSW_DOWNLOAD_URL := "https://download2.rstudio.org/server/bionic/amd64"
 RSW_LICENSE_SERVER := ""
 
 R_VERSION := "3.6.2"
@@ -19,6 +18,9 @@ PYTHON_VERSION_ALT := "3.8.10"
 
 PERSIST_LICENSE := "false"
 PERSIST_LICENSE_DIR := join(justfile_directory(), "tmp-lic")
+
+_get-download-url OS=IMAGE_OS:
+  echo "https://download2.rstudio.org/server/$(just -f ../Justfile _rev-parse-os {{OS}})/amd64"
 
 _make-default-tag OS=IMAGE_OS:
   echo "{{IMAGE_PREFIX}}{{PRODUCT}}:{{OS}}-$(just -f ../Justfile _get-tag-safe-version {{RSW_VERSION}})"
@@ -51,7 +53,7 @@ build OS=IMAGE_OS VERSION=RSW_VERSION *TAGS="":
     --build-arg R_VERSION_ALT="{{ R_VERSION_ALT }}" \
     --build-arg PYTHON_VERSION="{{ PYTHON_VERSION }}" \
     --build-arg PYTHON_VERSION_ALT="{{ PYTHON_VERSION_ALT }}" \
-    --build-arg RSW_DOWNLOAD_URL="{{ RSW_DOWNLOAD_URL }}" \
+    --build-arg RSW_DOWNLOAD_URL="$(just _get-download-url {{OS}})" \
     --file=./Dockerfile.$(just -f ../Justfile _parse-os {{OS}}) .
 
 # Test Workbench image - just test rstudio/rstudio-workbench:ubuntu1804-2022.07.2-576.pro12 2022.07.2+576.pro12


### PR DESCRIPTION
Fixes #485 

The hardcoded `RSW_DOWNLOAD_URL` in `workbench/Justfile` was causing failures for local Ubuntu 22.04 builds of Workbench. This fixes the problem by dynamically generating the URL based on OS.