### PR TITLE
Updating README to include language to recommend review/rebuild before use

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Docker images for RStudio Professional Products
    changes. We
    provide [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) for
    these cases.
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
+
  
 # Images
 

--- a/connect/README.md
+++ b/connect/README.md
@@ -37,6 +37,8 @@ https://www.rstudio.com/products/connect/.
    changes. We
    provide [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) for
    these cases.
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
+
 
 # How to use this image
 

--- a/content/README.md
+++ b/content/README.md
@@ -18,7 +18,6 @@ these pro images. Attempting to build a pro image using a content-base image tha
 does not exist will result in an error.
 
 
-
 ## Examine images
 
 The `scripts/build-image-yaml.sh` script that runs the

--- a/content/README.md
+++ b/content/README.md
@@ -18,6 +18,7 @@ these pro images. Attempting to build a pro image using a content-base image tha
 does not exist will result in an error.
 
 
+
 ## Examine images
 
 The `scripts/build-image-yaml.sh` script that runs the

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -36,6 +36,8 @@ installing the product on different operating systems, upgrading, and configurin
    a more secure option for configuring
    [Git-related package builds](https://docs.rstudio.com/rspm/admin/building-packages/) we recommend [using a system with
    sandboxing enabled](https://docs.rstudio.com/rspm/admin/process-management/#docker).
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
+
 
 # How to use this image
 

--- a/r-session-complete/README.md
+++ b/r-session-complete/README.md
@@ -26,6 +26,7 @@ Images for R and Python sessions and jobs to be used RStudio Workbench, Launcher
    changes. We
    provide [instructions for how to build and use](#how-to-use-these-docker-images)
    for these cases.
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
 
 # How to use these images
 

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -45,6 +45,8 @@ For more information on running RStudio Workbench in your organization please vi
    changes. We
    provide [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) for
    these cases.
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
+
 
 # How to use this image
 


### PR DESCRIPTION
The security team receives a number of tickets and escalations about the CVE/Vulnerability results of our image scans. We can't control certain elements of our images and so we're not easily going to be able to keep our images CVE free, as much as we'd like too. But what we should do is include language in the README that specifically calls the security risks of our existing images and that we recommend customers review and rebuild the images prior to production use.