### PR TITLE
Fix scheduled preview build

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -47,7 +47,8 @@ jobs:
       - name: Check Out main Branch
         if: github.event.schedule == '0 8 * * *'
         uses: actions/checkout@v3
-        ref: 'main'
+        with:
+          ref: 'main'
 
       - name: Check Out Repo at Triggered Branch
         if: github.event.schedule != '0 8 * * *'


### PR DESCRIPTION
### Checkout call block was missing the `with` statement.