### PR TITLE
Add jammy content images to the build matrix

### DIFF
--- a/content/base/Dockerfile.ubuntu2204
+++ b/content/base/Dockerfile.ubuntu2204
@@ -1,0 +1,132 @@
+# Using dated tags from https://hub.docker.com/_/ubuntu/
+FROM ubuntu:22.04
+
+LABEL maintainer="RStudio Docker <docker@rstudio.com>"
+
+# Locale configuration --------------------------------------------------------#
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends locales \
+    && localedef -i en_US -f UTF-8 en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Installation prerequisites --------------------------------------------------#
+# curl is used to download things.
+# libev-dev is required for most interactive Python applications.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      curl \
+      libev-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# System dependencies needed by popular R packages
+# https://docs.rstudio.com/rsc/post-setup-tool/#install-system-dependencies
+
+# Now, install the system requirements for R packages.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      default-jdk \
+      gdal-bin \
+      git \
+      gsfonts \
+      imagemagick \
+      libcairo2-dev \
+      libcurl4-openssl-dev \
+      libfontconfig1-dev \
+      libfreetype6-dev \
+      libfribidi-dev \
+      libgdal-dev \
+      libgeos-dev \
+      libgl1-mesa-dev \
+      libglpk-dev \
+      libglu1-mesa-dev \
+      libgmp3-dev \
+      libharfbuzz-dev \
+      libicu-dev \
+      libjpeg-dev \
+      libmagick++-dev \
+      libmysqlclient-dev \
+      libpng-dev \
+      libpq-dev \
+      libproj-dev \
+      libsodium-dev \
+      libssh2-1-dev \
+      libssl-dev \
+      libtiff-dev \
+      libudunits2-dev \
+      libv8-dev \
+      libicu-dev \
+      libxml2-dev \
+      make \
+      perl \
+      tcl \
+      tk \
+      tk-dev \
+      tk-table \
+      unixodbc-dev \
+      zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install TinyTeX --------------------------------------------------------------#
+
+# From https://github.com/rstudio/r-docker/blob/master/base/bionic/Dockerfile
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update  \
+    && apt-get install -y --no-install-recommends wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sL "https://yihui.org/tinytex/install-bin-unix.sh" | sh \
+    && /root/.TinyTeX/bin/*/tlmgr path remove \
+    && mv /root/.TinyTeX/ /opt/TinyTeX \
+    && /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin \
+    && /opt/TinyTeX/bin/*/tlmgr path add \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install R -------------------------------------------------------------------#
+
+# Reference: https://docs.rstudio.com/resources/install-r/
+
+# We are NOT linking one of these R versions into the PATH.
+
+ARG R_DISTRIBUTION=ubuntu-2204
+
+ARG R_VERSION=3.6.3
+ARG R_INSTALLER=r-${R_VERSION}_1_amd64.deb
+RUN curl -fsSL -O https://cdn.rstudio.com/r/${R_DISTRIBUTION}/pkgs/${R_INSTALLER} \
+    && apt-get update \
+    && apt-get install -f -y --no-install-recommends ./${R_INSTALLER} \
+    && rm ${R_INSTALLER} \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Install Python --------------------------------------------------------------#
+
+# Reference: https://docs.rstudio.com/resources/install-python/
+
+# We are NOT linking one of these Python versions into the PATH.
+
+ARG MINICONDA_VERSION=4.7.12.1
+ARG PYTHON_VERSION=3.7.6
+
+# The documented approach uses a particular miniconda install script version
+# to obtain the desired Python version. We are first installing miniconda and
+# then asking it to install different Python versions.
+
+RUN curl -fsSL -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh \
+    && chmod 755 miniconda.sh \
+    && ./miniconda.sh -b -p /opt/miniconda \
+    && /opt/miniconda/bin/conda create --quiet --yes --prefix /opt/python/${PYTHON_VERSION} python=${PYTHON_VERSION} virtualenv \
+    && rm -f miniconda.sh \
+    # remove miniconda too, for size
+    && rm -rf /opt/miniconda
+
+# install quarto
+ARG QUARTO_VERSION=1.3.330
+COPY maybe_install_quarto.sh /tmp/maybe_install_quarto.sh
+RUN /opt/R/${R_VERSION}/bin/R -e 'install.packages("odbc", repos="https://packagemanager.rstudio.com/cran/__linux__/jammy/latest")' \
+    && /tmp/maybe_install_quarto.sh \
+    && rm -f /tmp/maybe_install_quarto.sh

--- a/content/base/maybe_install_quarto.sh
+++ b/content/base/maybe_install_quarto.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
-# only install quarto if python 3.10 and R 4.1
+# on bionic, only install quarto if python 3.10 and R 4.1
 # TODO: figure out a different hierarchy...
-if [[ `ls /opt/python/ | grep '3\.10\.'` ]] && [[ `ls /opt/R | grep '4\.1\.'` ]]; then
+if [[ `grep -oE bionic /etc/lsb-release` ]] && [[ `ls /opt/python/ | grep '3\.10\.'` ]] && [[ `ls /opt/R | grep '4\.1\.'` ]]; then
   qver=${QUARTO_VERSION:-1.0.37}
+  echo '--> Installing Quarto'
+  curl -L -o /quarto.deb https://github.com/quarto-dev/quarto-cli/releases/download/v${qver}/quarto-${qver}-linux-amd64.deb
+  apt install /quarto.deb
+  rm -f /quarto.deb
+fi
+
+# on jammy, always install quarto
+if [[ `grep -oE jammy /etc/lsb-release` ]]; then
+  qver=${QUARTO_VERSION:-1.3.330}
   echo '--> Installing Quarto'
   curl -L -o /quarto.deb https://github.com/quarto-dev/quarto-cli/releases/download/v${qver}/quarto-${qver}-linux-amd64.deb
   apt install /quarto.deb

--- a/content/matrix.json
+++ b/content/matrix.json
@@ -16,5 +16,9 @@
   {"r": "4.0.5", "py": "3.9.2", "drivers": "2022.11.0", "os": "ubuntu1804", "os_alt": "bionic"},
   {"r": "4.1.0", "py": "3.8.8", "drivers": "2022.11.0", "os": "ubuntu1804", "os_alt": "bionic"},
   {"r": "4.1.0", "py": "3.9.2", "drivers": "2022.11.0", "os": "ubuntu1804", "os_alt": "bionic"},
-  {"r": "4.1.3", "py": "3.10.4", "drivers": "2022.11.0", "os": "ubuntu1804", "os_alt": "bionic"}
+  {"r": "4.1.3", "py": "3.10.4", "drivers": "2022.11.0", "os": "ubuntu1804", "os_alt": "bionic"},
+  {"r": "3.6.3", "py": "3.8.16", "drivers": "2022.11.0", "os": "ubuntu2204", "os_alt": "jammy"},
+  {"r": "4.0.5", "py": "3.9.16", "drivers": "2022.11.0", "os": "ubuntu2204", "os_alt": "jammy"},
+  {"r": "4.1.3", "py": "3.10.11", "drivers": "2022.11.0", "os": "ubuntu2204", "os_alt": "jammy"},
+  {"r": "4.2.1", "py": "3.11.3", "drivers": "2022.11.0", "os": "ubuntu2204", "os_alt": "jammy"}
 ]

--- a/content/pro/Dockerfile.ubuntu2204
+++ b/content/pro/Dockerfile.ubuntu2204
@@ -1,0 +1,20 @@
+ARG PYTHON_VERSION
+ARG R_VERSION
+FROM rstudio/content-base:r${R_VERSION}-py${PYTHON_VERSION}-jammy
+
+LABEL maintainer="RStudio Docker <docker@rstudio.com>"
+
+# Install RStudio Professional Drivers ----------------------------------------#
+ARG DRIVERS_VERSION
+ARG R_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends unixodbc unixodbc-dev gdebi-core \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -O https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb \
+    && apt-get update \
+    && gdebi --non-interactive rstudio-drivers_${DRIVERS_VERSION}_amd64.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini


### PR DESCRIPTION
- Modify maybe_install_quarto.sh to only install quarto for 1 version of bionic. 
- Install latest RC quarto (as of 2023-04-18) for _all_ jammy images.