### PR TITLE
quarto 1.3.340

### DIFF
--- a/connect/Dockerfile.ubuntu1804
+++ b/connect/Dockerfile.ubuntu1804
@@ -93,6 +93,13 @@ RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64
     /opt/python/${PYTHON_VERSION_ALT}/bin/pip install --upgrade setuptools && \
     rm -rf Miniconda3-*-Linux-x86_64.sh
 
+# Install Quarto --------------------------------------------------------------#
+ARG QUARTO_VERSION=1.3.340
+RUN curl -L -o /quarto.tar.gz "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" \
+    && mkdir -p /opt/quarto/${QUARTO_VERSION} \
+    && tar -zxvf quarto.tar.gz -C "/opt/quarto/${QUARTO_VERSION}" --strip-components=1 \
+    && rm -f /quarto.tar.gz
+
 # Runtime settings ------------------------------------------------------------#
 ARG TINI_VERSION=0.18.0
 RUN curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini && \

--- a/connect/Dockerfile.ubuntu2204
+++ b/connect/Dockerfile.ubuntu2204
@@ -73,22 +73,30 @@ RUN apt-get update -qq && \
 
 # Install Python  -------------------------------------------------------------#
 ARG PYTHON_VERSION=3.9.5
-RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh && \
-    bash Miniconda3-4.7.12.1-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/conda install -y python==${PYTHON_VERSION} && \
-    /opt/python/${PYTHON_VERSION}/bin/pip install 'virtualenv<20' && \
-    /opt/python/${PYTHON_VERSION}/bin/pip install --upgrade setuptools && \
-    rm -rf Miniconda3-*-Linux-x86_64.sh
+RUN apt-get update -qq \
+    && curl -O https://cdn.rstudio.com/python/ubuntu-2204/pkgs/python-${PYTHON_VERSION}_1_amd64.deb \
+    && DEBIAN_FRONTEND=noninteractive gdebi -n python-${PYTHON_VERSION}_1_amd64.deb \
+    && /opt/python/"${PYTHON_VERSION}"/bin/pip install --upgrade pip setuptools wheel \
+    && rm -f ./python-${PYTHON_VERSION}_1_amd64.deb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install another Python --------------------------------------------------------------#
-
+# Install another Python ------------------------------------------------------#
 ARG PYTHON_VERSION_ALT=3.8.10
-RUN curl -O https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh && \
-    bash Miniconda3-4.7.12.1-Linux-x86_64.sh -bp /opt/python/${PYTHON_VERSION_ALT} && \
-    /opt/python/${PYTHON_VERSION_ALT}/bin/conda install -y python==${PYTHON_VERSION_ALT} && \
-    /opt/python/${PYTHON_VERSION_ALT}/bin/pip install 'virtualenv<20' && \
-    /opt/python/${PYTHON_VERSION_ALT}/bin/pip install --upgrade setuptools && \
-    rm -rf Miniconda3-*-Linux-x86_64.sh
+RUN apt-get update -qq \
+    && curl -O https://cdn.rstudio.com/python/ubuntu-2204/pkgs/python-${PYTHON_VERSION_ALT}_1_amd64.deb \
+    && DEBIAN_FRONTEND=noninteractive gdebi -n python-${PYTHON_VERSION_ALT}_1_amd64.deb \
+    && /opt/python/"${PYTHON_VERSION_ALT}"/bin/pip install --upgrade pip setuptools wheel \
+    && rm -f ./python-${PYTHON_VERSION_ALT}_1_amd64.deb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Quarto --------------------------------------------------------------#
+ARG QUARTO_VERSION=1.3.340
+RUN curl -L -o /quarto.tar.gz "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" \
+    && mkdir -p /opt/quarto/${QUARTO_VERSION} \
+    && tar -zxvf quarto.tar.gz -C "/opt/quarto/${QUARTO_VERSION}" --strip-components=1 \
+    && rm -f /quarto.tar.gz
 
 # Runtime settings ------------------------------------------------------------#
 ARG TINI_VERSION=0.18.0

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,11 @@
+# 2023-04-26
+
+- Add Quarto 1.3.340 to the Ubuntu 18.04 and Ubuntu 22.04 images.
+- Enable and configure Connect Quarto support, using the Quarto 1.3.340
+  installation.
+- Install Python from https://github.com/rstudio/python-builds into the Ubuntu
+  22.04 images without; these installations do not contain `virtualenv`.
+
 # 2022-01-23
 
 - Add documentation for license leak bug and possible workarounds/solutions.

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -4,7 +4,7 @@
 - Enable and configure Connect Quarto support, using the Quarto 1.3.340
   installation.
 - Install Python from https://github.com/rstudio/python-builds into the Ubuntu
-  22.04 images without; these installations do not contain `virtualenv`.
+  22.04 images; these installations do not contain `virtualenv`.
 
 # 2022-01-23
 

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -3,8 +3,8 @@
 - Add Quarto 1.3.340 to the Ubuntu 18.04 and Ubuntu 22.04 images.
 - Enable and configure Connect Quarto support, using the Quarto 1.3.340
   installation.
-- Install Python from https://github.com/rstudio/python-builds into the Ubuntu
-  22.04 images; these installations do not contain `virtualenv`.
+- Replace Miniconda-based Python installation with Python from https://github.com/rstudio/python-builds in the Ubuntu
+  22.04 images. These installations do not contain `virtualenv`.
 
 # 2022-01-23
 

--- a/connect/rstudio-connect.gcfg
+++ b/connect/rstudio-connect.gcfg
@@ -33,6 +33,10 @@ Enabled = true
 Executable = /opt/python/3.8.10/bin/python
 Executable = /opt/python/3.9.5/bin/python
 
+[Quarto]
+Enabled = true
+Executable = /opt/quarto/1.3.340/bin/quarto
+
 [RPackageRepository "CRAN"]
 URL = https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
 

--- a/content/base/Dockerfile.ubuntu2204
+++ b/content/base/Dockerfile.ubuntu2204
@@ -114,7 +114,6 @@ RUN curl -fsSL -O https://cdn.rstudio.com/r/${DISTRIBUTION}/pkgs/${R_INSTALLER} 
 RUN curl -O https://cdn.rstudio.com/python/${DISTRIBUTION}/pkgs/python-${PYTHON_VERSION}_1_amd64.deb \
     && apt-get install -yq --no-install-recommends ./python-${PYTHON_VERSION}_1_amd64.deb \
     && rm -rf python-${PYTHON_VERSION}_1_amd64.deb \
-    && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install 'virtualenv<20' \
     && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install --upgrade setuptools
 
 # install quarto

--- a/content/base/NEWS.md
+++ b/content/base/NEWS.md
@@ -1,3 +1,8 @@
+# 2023-04-26
+
+- Use the Quarto release 1.3.340 in jammy images.
+- Install Python without `virtualenv`.
+
 # 2022-07-18
 
 - Add quarto to R 4.1 and Python 3.10 build

--- a/content/base/maybe_install_quarto.sh
+++ b/content/base/maybe_install_quarto.sh
@@ -12,9 +12,10 @@ fi
 
 # on jammy, always install quarto
 if [[ `grep -oE jammy /etc/lsb-release` ]]; then
-  qver=${QUARTO_VERSION:-1.3.330}
+  qver=${QUARTO_VERSION:-1.3.340}
   echo '--> Installing Quarto'
-  curl -L -o /quarto.deb https://github.com/quarto-dev/quarto-cli/releases/download/v${qver}/quarto-${qver}-linux-amd64.deb
-  apt install /quarto.deb
-  rm -f /quarto.deb
+  curl -L -o /quarto.tar.gz "https://github.com/quarto-dev/quarto-cli/releases/download/v${qver}/quarto-${qver}-linux-amd64.tar.gz"
+  mkdir -p /opt/quarto/${qver}
+  tar -zxvf quarto.tar.gz -C "/opt/quarto/${qver}" --strip-components=1
+  rm -f /quarto.tar.gz
 fi


### PR DESCRIPTION
* Quarto 1.3.340 used in content images; installed to /opt/quarto/1.3.340
* Python in Ubuntu 22.04 content images without virtualenv
* Quarto 1.3.340 used in Connect images; installed to /opt/quarto/1.3.340
* Python in Connect Ubuntu 22.04 images installed from python-builds without virtualenv