### PR TITLE
stop pushing on non-main branches

### DIFF
--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -86,7 +86,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
-        #if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -94,7 +94,7 @@ jobs:
           password: ${{ secrets.BUILD_PAT }}
 
       - name: Push image(s) to registries
-        #if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           just -f ci.Justfile push-images ${{ steps.build-base-image.outputs.TAGS }}
 
@@ -186,7 +186,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Push image(s) to registries
-        #if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           just -f ci.Justfile push-images ${{ steps.build-pro-image.outputs.TAGS }}
 


### PR DESCRIPTION
If we want to follow up on a "better" pattern for building the full pipeline on test branches, we should take that as a separate item. The fact that random branches can overwrite prod images without warning should be removed.