### PR TITLE
Update VSCode Python Ext Version for Session Image

### DIFF
--- a/r-session-complete/vscode.extensions.conf
+++ b/r-session-complete/vscode.extensions.conf
@@ -1,3 +1,3 @@
 quarto.quarto
 Ikuyadeu.r@2.4.0
-ms-python.python@2022.10.1
+ms-python.python@2023.6.1


### PR DESCRIPTION
This PR updates the Python Extension version installed for the session image, which addresses rstudio/rstudio-pro#4364 where interactive jupyter plots aren't working on Kubernetes.