### PR TITLE
Remove "dev-" prefixing for preview/daily builds

### DIFF
--- a/ci.Justfile
+++ b/ci.Justfile
@@ -176,13 +176,6 @@ build-preview $TYPE $PRODUCT $OS $VERSION $BRANCH=`git branch --show`:
   TAG_CLEAN_VERSION=`just _get-clean-version $VERSION`
   TAG_VERSION=`just _get-tag-safe-version $VERSION`
 
-  # set branch prefix
-  if [[ $BRANCH == "dev" ]]; then
-    BRANCH_PREFIX="dev-"
-  elif [[ $BRANCH == "dev-rspm" ]]; then
-    BRANCH_PREFIX="dev-rspm-"
-  fi
-
   # set short name
   if [[ $PRODUCT == "workbench" || $PRODUCT == "r-session-complete" || $PRODUCT == "workbench-for-microsoft-azure-ml" ]]; then
     SHORT_NAME="RSW"


### PR DESCRIPTION
I spoke with the IDE team this morning and we determined the "dev-" prefix was causing some confusion over what branch was being used after the branch restructure. Since really all they need is the suffix version, I think we can completely remove the "dev-" prefixes for preview builds. 