### PR TITLE
Skip `tidymodels` test for R 3.5.3

### DIFF
--- a/ci.Justfile
+++ b/ci.Justfile
@@ -176,6 +176,13 @@ build-preview $TYPE $PRODUCT $OS $VERSION $BRANCH=`git branch --show`:
   TAG_CLEAN_VERSION=`just _get-clean-version $VERSION`
   TAG_VERSION=`just _get-tag-safe-version $VERSION`
 
+  # set branch prefix
+  if [[ $BRANCH == "dev" ]]; then
+    BRANCH_PREFIX="dev-"
+  elif [[ $BRANCH == "dev-rspm" ]]; then
+    BRANCH_PREFIX="dev-rspm-"
+  fi
+
   # set short name
   if [[ $PRODUCT == "workbench" || $PRODUCT == "r-session-complete" || $PRODUCT == "workbench-for-microsoft-azure-ml" ]]; then
     SHORT_NAME="RSW"

--- a/ci.Justfile
+++ b/ci.Justfile
@@ -176,13 +176,6 @@ build-preview $TYPE $PRODUCT $OS $VERSION $BRANCH=`git branch --show`:
   TAG_CLEAN_VERSION=`just _get-clean-version $VERSION`
   TAG_VERSION=`just _get-tag-safe-version $VERSION`
 
-  # set branch prefix
-  if [[ $BRANCH == "dev" ]]; then
-    BRANCH_PREFIX="dev-"
-  elif [[ $BRANCH == "dev-rspm" ]]; then
-    BRANCH_PREFIX="dev-rspm-"
-  fi
-
   # set short name
   if [[ $PRODUCT == "workbench" || $PRODUCT == "r-session-complete" || $PRODUCT == "workbench-for-microsoft-azure-ml" ]]; then
     SHORT_NAME="RSW"

--- a/workbench-for-microsoft-azure-ml/test/goss.yaml
+++ b/workbench-for-microsoft-azure-ml/test/goss.yaml
@@ -139,7 +139,9 @@ command:
   {{$rver}} --slave -e 'library()' | cut -f 1 -d ' ' | grep -v '^Packages$' | grep -v '^$':
     exit-status: 0
     stdout:
-      {{range $pkg := $pkgs}}
+    {{range $pkg := $pkgs}}
+      {{ if not (and (eq $pkg "tidymodels") (eq $rver "/opt/R/3.5.3/bin/R")) }}
       - {{ $pkg }}
       {{end}}
+    {{end}}
   {{end}}


### PR DESCRIPTION
Closes #548 

Workbench for Azure ML is currently failing tests due to `timeDate` (a sub-dependency of `tidymodels`) no longer being supported in R versions <3.6. By disabling the test for `tidymodels` presence in R 3.5.3, we can continue to get new image builds released. 

At some point we may want to fully disable tests for R 3.5.3 as we did with R 3.4.4 or remove these older versions in favor of a new version, such as R 4.3.0.