### PR TITLE
Add `cracklib-runtime` to base image package list

### DIFF
--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -12,6 +12,8 @@ group:
 package:
   rstudio-connect:
     installed: true
+  cracklib-runtime:
+    installed: true
 
 port:
   tcp6:3939:
@@ -46,6 +48,9 @@ file:
     exists: true
     contains:
     - "!Error: Couldn't read configuration file "
+  # Check that `cracklib-runtime` is present so `chpasswd` works
+  /var/cache/cracklib/cracklib_dict.pwd:
+    exists: true
 
 # Check product version
 command:

--- a/product/base/Dockerfile.ubuntu1804
+++ b/product/base/Dockerfile.ubuntu1804
@@ -17,6 +17,7 @@ RUN apt-get update --fix-missing  \
         apt-transport-https \
         ca-certificates \
         cmake \
+        cracklib-runtime \
         curl \
         default-jdk \
         dirmngr \

--- a/product/base/Dockerfile.ubuntu2204
+++ b/product/base/Dockerfile.ubuntu2204
@@ -17,6 +17,7 @@ RUN apt-get update --fix-missing  \
         apt-transport-https \
         ca-certificates \
         cmake \
+        cracklib-runtime \
         curl \
         default-jdk \
         dirmngr \

--- a/product/base/test/goss.yaml
+++ b/product/base/test/goss.yaml
@@ -4,6 +4,8 @@ package:
   {{if .Env.OS | regexMatch "ubuntu.*"}}
   gpg:
     installed: true
+  cracklib-runtime:
+    installed: true
   {{end}}
   {{if .Env.OS | regexMatch "centos.*"}}
   epel-release:
@@ -25,6 +27,11 @@ file:
     exists: true
   /opt/quarto/{{.Env.QUARTO_VERSION}}/bin/quarto:
     exists: true
+  {{if .Env.OS | regexMatch "ubuntu.*"}}
+  # Check that `cracklib-runtime` is present so `chpasswd` works
+  /var/cache/cracklib/cracklib_dict.pwd:
+    exists: true
+  {{end}}
 
 command:
 # Ensure correct R version


### PR DESCRIPTION
`cracklib-runtime` was briefly missing from the `ubuntu` Docker image, causing `chpasswd` calls to fail. It appears that this package has been added back into the `ubuntu` base image, but I don't think it will hurt to check for it and install it if it's missing in the future.