### PR TITLE
Add post 07/25/23 gpg key

### DIFF
--- a/connect/Dockerfile.ubuntu2204
+++ b/connect/Dockerfile.ubuntu2204
@@ -26,7 +26,7 @@ RUN apt-get update --fix-missing \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages
-    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
+    && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify rstudio-connect.deb \
     && apt-get install -yq --no-install-recommends ./rstudio-connect.deb \
     && rm -rf ./rstudio-connect.deb \

--- a/connect/Dockerfile.ubuntu2204
+++ b/connect/Dockerfile.ubuntu2204
@@ -23,7 +23,10 @@ RUN apt-get update --fix-missing \
       libglib2.0-0 \
     && RSC_VERSION_URL=$(echo -n "${RSC_VERSION}" | sed 's/+/%2B/g') \
     && curl -L -o rstudio-connect.deb "https://cdn.rstudio.com/connect/$(echo $RSC_VERSION | sed -r 's/([0-9]+\.[0-9]+).*/\1/')/rstudio-connect_${RSC_VERSION_URL}~ubuntu22_amd64.deb" \
+    # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
+    # Post 7/25 packages
+    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify rstudio-connect.deb \
     && apt-get install -yq --no-install-recommends ./rstudio-connect.deb \
     && rm -rf ./rstudio-connect.deb \

--- a/package-manager/Dockerfile.ubuntu1804
+++ b/package-manager/Dockerfile.ubuntu1804
@@ -35,7 +35,7 @@ RUN apt-get update --fix-missing \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages
-    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
+    && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 gdebi -n rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \

--- a/package-manager/Dockerfile.ubuntu1804
+++ b/package-manager/Dockerfile.ubuntu1804
@@ -32,7 +32,10 @@ ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu/amd64
 RUN apt-get update --fix-missing \
     && apt-get install -y --no-install-recommends gdebi-core dpkg-sig \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
+    # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
+    # Post 7/25 packages
+    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 gdebi -n rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \

--- a/package-manager/Dockerfile.ubuntu2204
+++ b/package-manager/Dockerfile.ubuntu2204
@@ -35,7 +35,7 @@ RUN apt-get update --fix-missing \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages
-    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
+    && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 gdebi -n rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \

--- a/package-manager/Dockerfile.ubuntu2204
+++ b/package-manager/Dockerfile.ubuntu2204
@@ -32,7 +32,10 @@ ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu22/amd64
 RUN apt-get update --fix-missing \
     && apt-get install -y --no-install-recommends gdebi-core dpkg-sig \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
+    # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
+    # Post 7/25 packages
+    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 gdebi -n rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \

--- a/r-session-complete/Dockerfile.centos7
+++ b/r-session-complete/Dockerfile.centos7
@@ -23,7 +23,7 @@ RUN yum install -y subversion \
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     && gpg --export --armor 3F32EE77E331692F > rstudio-signing.key \
     # Post 7/25 packages
-    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
+    && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
     && gpg --export --armor 51C0B5BB19F92D60 > rstudio-signing.key \
     && rpm --import rstudio-signing.key \
     && rpm -K rstudio-workbench.rpm \

--- a/r-session-complete/Dockerfile.centos7
+++ b/r-session-complete/Dockerfile.centos7
@@ -22,8 +22,9 @@ RUN yum install -y subversion \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     && gpg --export --armor 3F32EE77E331692F > rstudio-signing.key \
+    && rpm --import rstudio-signing.key \
     # Post 7/25 packages
-    && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
+    && gpg --keyserver hkps://keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
     && gpg --export --armor 51C0B5BB19F92D60 > rstudio-signing.key \
     && rpm --import rstudio-signing.key \
     && rpm -K rstudio-workbench.rpm \

--- a/r-session-complete/Dockerfile.centos7
+++ b/r-session-complete/Dockerfile.centos7
@@ -19,8 +19,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN yum install -y subversion \
     && RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
     && curl -o rstudio-workbench.rpm "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-x86_64.rpm" \
+    # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     && gpg --export --armor 3F32EE77E331692F > rstudio-signing.key \
+    # Post 7/25 packages
+    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
+    && gpg --export --armor 51C0B5BB19F92D60 > rstudio-signing.key \
     && rpm --import rstudio-signing.key \
     && rpm -K rstudio-workbench.rpm \
     && yum install -y rstudio-workbench.rpm \

--- a/r-session-complete/Dockerfile.ubuntu2204
+++ b/r-session-complete/Dockerfile.ubuntu2204
@@ -30,7 +30,10 @@ RUN apt-get update \
       subversion \
     && RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
     && curl -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb" \
+    # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
+    # Post 7/25 packages
+    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify ./rstudio-workbench.deb \
     && apt-get install -yq --no-install-recommends ./rstudio-workbench.deb \
     && rm ./rstudio-workbench.deb \

--- a/r-session-complete/Dockerfile.ubuntu2204
+++ b/r-session-complete/Dockerfile.ubuntu2204
@@ -33,7 +33,7 @@ RUN apt-get update \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages
-    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
+    && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify ./rstudio-workbench.deb \
     && apt-get install -yq --no-install-recommends ./rstudio-workbench.deb \
     && rm ./rstudio-workbench.deb \

--- a/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
+++ b/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
@@ -57,7 +57,10 @@ RUN apt-get update \
       sssd \
       supervisor \
     && curl -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION//+/-}-amd64.deb" \
+    # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
+    # Post 7/25 packages
+    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify ./rstudio-workbench.deb \
     && apt-get install -yq --no-install-recommends ./rstudio-workbench.deb \
     && rm ./rstudio-workbench.deb \

--- a/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
+++ b/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
@@ -60,7 +60,7 @@ RUN apt-get update \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages
-    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
+    && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify ./rstudio-workbench.deb \
     && apt-get install -yq --no-install-recommends ./rstudio-workbench.deb \
     && rm ./rstudio-workbench.deb \

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -55,7 +55,7 @@ RUN apt-get update \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages
-    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
+    && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify ./rstudio-workbench.deb \
     && apt-get install -yq --no-install-recommends ./rstudio-workbench.deb \
     && rm ./rstudio-workbench.deb \

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -52,7 +52,10 @@ RUN apt-get update \
       supervisor \
     && RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
     && curl -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb" \
+    # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
+    # Post 7/25 packages
+    && gpg --keyserver keys.openpgp.org --search-keys 51C0B5BB19F92D60 \
     && dpkg-sig --verify ./rstudio-workbench.deb \
     && apt-get install -yq --no-install-recommends ./rstudio-workbench.deb \
     && rm ./rstudio-workbench.deb \


### PR DESCRIPTION
[Posit code signing](https://posit.co/code-signing/) updated as of 07/25/23. This change adds the new key alongside the old one. We'll eventually remove the old one in the future once we don't need to worry about backwards compatibility with older builds.