### PR TITLE
Add `ca-certificates` and explicit `gpg` install to PPM build

### DIFF
--- a/package-manager/Dockerfile.ubuntu1804
+++ b/package-manager/Dockerfile.ubuntu1804
@@ -32,7 +32,7 @@ RUN apt-get update -qq && \
 ARG RSPM_VERSION=2023.04.0-6
 ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu/amd64
 RUN apt-get update --fix-missing \
-    && apt-get install -y --no-install-recommends gdebi-core dpkg-sig \
+    && apt-get install -y --no-install-recommends ca-certificates gdebi-core gpg dpkg-sig \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \

--- a/package-manager/Dockerfile.ubuntu1804
+++ b/package-manager/Dockerfile.ubuntu1804
@@ -41,7 +41,7 @@ RUN apt-get update --fix-missing \
     && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 gdebi -n rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \
-    && apt-get purge -y gdebi-core dpkg-sig \
+    && apt-get purge -y gdebi-core dpkg-sig gpg \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/package-manager/Dockerfile.ubuntu2204
+++ b/package-manager/Dockerfile.ubuntu2204
@@ -41,7 +41,7 @@ RUN apt-get update --fix-missing \
     && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 gdebi -n rstudio-pm_${RSPM_VERSION}_amd64.deb \
     && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \
-    && apt-get purge -y gdebi-core dpkg-sig \
+    && apt-get purge -y gdebi-core dpkg-sig gpg \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/package-manager/Dockerfile.ubuntu2204
+++ b/package-manager/Dockerfile.ubuntu2204
@@ -32,7 +32,7 @@ RUN apt-get update -qq && \
 ARG RSPM_VERSION=2023.04.0-6
 ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu22/amd64
 RUN apt-get update --fix-missing \
-    && apt-get install -y --no-install-recommends gdebi-core dpkg-sig \
+    && apt-get install -y --no-install-recommends ca-certificates gdebi-core gpg dpkg-sig \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \


### PR DESCRIPTION
GPG calls to keys.openpgp.org will fail without updated `ca-certificates`. We can explicitly install the certificates to prevent failures in signature verification.