### PR TITLE
Use `main` branch for scheduled release rebuild

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -27,7 +27,14 @@ jobs:
           - {os: 'ubuntu2204', r-primary: "4.2.3", r-alternate: "4.1.3", py-primary: "3.9.17", py-alternate: "3.8.17"}
 
     steps:
+      - name: Check Out Repo - cron main
+        if: github.event.schedule == '0 12 * * 1'
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
       - name: Check Out Repo
+        if: github.event.schedule != '0 12 * * 1'
         uses: actions/checkout@v3
 
       - name: Set up Just
@@ -126,7 +133,14 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      - name: Check Out Repo - cron main
+        if: github.event.schedule == '0 12 * * 1'
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
       - name: Check Out Repo
+        if: github.event.schedule != '0 12 * * 1'
         uses: actions/checkout@v3
 
       - name: Set up Just
@@ -228,7 +242,14 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      - name: Check Out Repo - cron main
+        if: github.event.schedule == '0 12 * * 1'
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
       - name: Check Out Repo
+        if: github.event.schedule != '0 12 * * 1'
         uses: actions/checkout@v3
 
       - name: Set up Just
@@ -329,7 +350,14 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      - name: Check Out Repo - cron main
+        if: github.event.schedule == '0 12 * * 1'
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
       - name: Check Out Repo
+        if: github.event.schedule != '0 12 * * 1'
         uses: actions/checkout@v3
 
       - name: Set up Just


### PR DESCRIPTION
Since `dev` is the default branch for the repo, we have to explicitly checkout `main` for our scheduled rebuilds.