### PR TITLE
fix: update download path for PPM Dockerfiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     container_name: rstudio-package-manager
     build:
       context: ./package-manager
-      dockerfile: "Dockerfile.${IMAGE_OS:-ubuntu1804}"
+      dockerfile: "Dockerfile.${IMAGE_OS:-ubuntu2204}"
       args:
         RSPM_VERSION: 2023.04.0-6
     image: rstudio/rstudio-package-manager:2023.04.0

--- a/package-manager/Dockerfile.ubuntu1804
+++ b/package-manager/Dockerfile.ubuntu1804
@@ -49,7 +49,7 @@ RUN apt-get update -qq && \
 
 # Download RStudio Package Manager ---------------------------------------------#
 ARG RSPM_VERSION=2023.04.0-6
-ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu/amd64
+ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/deb/amd64
 # Keys must be pulled using curl, gpg calls intermittently fail on 18.04 with "gpg: keyserver receive failed: Cannot assign requested address"
 RUN apt-get update --fix-missing \
     && apt-get install -y --no-install-recommends gdebi-core gpg dpkg-sig \

--- a/package-manager/Dockerfile.ubuntu2204
+++ b/package-manager/Dockerfile.ubuntu2204
@@ -45,7 +45,7 @@ RUN apt-get update -qq && \
 
 # Download RStudio Package Manager ---------------------------------------------#
 ARG RSPM_VERSION=2023.04.0-6
-ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/ubuntu22/amd64
+ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/deb/amd64
 RUN apt-get update --fix-missing \
     && apt-get install -y --no-install-recommends ca-certificates gdebi-core gpg dpkg-sig \
     && curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \


### PR DESCRIPTION
### Description

Updates the `Dockerfile.ubuntu2204` and `Dockerfile.ubuntu1804` PPM download paths to point to the correct URL. Also updates the `docker-compose.yml` to use `ubuntu2204` instead of `ubuntu1804`.