### PR TITLE
Updates for Workbench 2022.07.4 backwards compatibility

### DIFF
--- a/.github/workflows/build-manual.yaml
+++ b/.github/workflows/build-manual.yaml
@@ -42,6 +42,11 @@ on:
           - preview
           - daily
           - release
+      use_s3_download_url:
+        description: "Force build to download binaries directly from S3 where applicable."
+        required: false
+        default: false
+        type: boolean
       version:
         description: "The version to build. Use 'auto' to target the latest build."
         required: false
@@ -89,8 +94,12 @@ jobs:
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           ARGS_CMD=""
+          USE_S3_DOWNLOAD_URL=""
           if [[ "${{ inputs.type }}" == "release" ]]; then
             ARGS_CMD="get-product-args"
+            if [[ "${{ inputs.use_s3_download_url }}" == "true" ]]; then
+              USE_S3_DOWNLOAD_URL="${{ inputs.use_s3_download_url }}"
+            fi
           else
             ARGS_CMD="get-prerelease-args ${{inputs.type}}"
           fi
@@ -100,6 +109,7 @@ jobs:
               ${{ inputs.product }} \
               ${{ inputs.os }} \
               ${{ steps.get-version.outputs.VERSION }} \
+              ${USE_S3_DOWNLOAD_URL} \
           )
           echo "BUILD_ARGS<<$EOF" >> $GITHUB_OUTPUT
           echo "$BUILD_ARGS" >> $GITHUB_OUTPUT

--- a/ci.Justfile
+++ b/ci.Justfile
@@ -109,10 +109,14 @@ get-base-tags $OS $TYPE="base" $BRANCH=`git branch --show`:
   ghcr.io/rstudio/${IMAGE_NAME}:${OS}
 
 # just get-product-args connect ubuntu2204 2023.05.0
-get-product-args $PRODUCT $OS $VERSION $BRANCH=`git branch --show` $SHA_SHORT=`git rev-parse --short HEAD`:
+get-product-args $PRODUCT $OS $VERSION $USE_S3="false" $BRANCH=`git branch --show` $SHA_SHORT=`git rev-parse --short HEAD`:
   #!/usr/bin/env bash
   set -euxo pipefail
+
   RSW_DOWNLOAD_URL=$(just -f ci.Justfile _get-rsw-download-url release $OS)
+  if [[ "${USE_S3}" == "true" ]]; then
+    RSW_DOWNLOAD_URL=$(just -f ci.Justfile _get-rsw-download-url preview $OS)
+  fi
 
   if [[ $PRODUCT == "workbench" || $PRODUCT == "r-session-complete" || $PRODUCT == "workbench-for-microsoft-azure-ml" ]]; then
     SHORT_NAME="RSW"

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -67,6 +67,10 @@ RUN apt-get update \
     && rm -rf /var/lib/rstudio-server/r-versions \
     && rm -rf /var/lib/rstudio-launcher/Local/jobs/buildkitsandbox
 
+COPY maybe_install_vs_code.sh /tmp/maybe_install_vs_code.sh
+RUN /tmp/maybe_install_vs_code.sh \
+    && rm /tmp/maybe_install_vs_code.sh
+
 COPY --chmod=0775 startup.sh /usr/local/bin/startup.sh
 COPY startup-launcher/* /startup/launcher/
 COPY startup-user-provisioning/* /startup/user-provisioning/

--- a/workbench/Justfile
+++ b/workbench/Justfile
@@ -7,6 +7,7 @@ PRODUCT := "workbench"
 IMAGE_OS := "ubuntu2204"
 
 RSW_VERSION := "2023.09.1+494.pro2"
+RSW_RELEASE_TYPE := "release"
 RSW_LICENSE := ""
 RSW_LICENSE_SERVER := ""
 
@@ -19,11 +20,8 @@ PYTHON_VERSION_ALT := "3.8.17"
 PERSIST_LICENSE := "false"
 PERSIST_LICENSE_DIR := join(justfile_directory(), "tmp-lic")
 
-_get-download-url OS=IMAGE_OS:
-  echo "https://download2.rstudio.org/server/$(just -f ../Justfile _rev-parse-os {{OS}})/amd64"
-
-_make-default-tag OS=IMAGE_OS:
-  echo "{{IMAGE_PREFIX}}{{PRODUCT}}:{{OS}}-$(just -f ../Justfile _get-tag-safe-version {{RSW_VERSION}})"
+_make-default-tag OS=IMAGE_OS VERSION=RSW_VERSION:
+  echo "{{IMAGE_PREFIX}}{{PRODUCT}}:{{OS}}-$(just -f ../Justfile _get-tag-safe-version {{VERSION}})"
 
 # Build Workbench image - just build ubuntu2204 2022.07.2+576.pro12 rstudio/rstudio-workbench:ubuntu2204-2022.07.2-576.pro12
 build OS=IMAGE_OS VERSION=RSW_VERSION *TAGS="":
@@ -35,7 +33,7 @@ build OS=IMAGE_OS VERSION=RSW_VERSION *TAGS="":
   fi
 
   if [[ "{{TAGS}}" == "" ]]; then
-    raw_tag_array=($(just _make-default-tag {{OS}}))
+    raw_tag_array=($(just _make-default-tag {{OS}} {{VERSION}}))
   else
     raw_tag_array=("{{TAGS}}")
   fi
@@ -53,7 +51,7 @@ build OS=IMAGE_OS VERSION=RSW_VERSION *TAGS="":
     --build-arg R_VERSION_ALT="{{ R_VERSION_ALT }}" \
     --build-arg PYTHON_VERSION="{{ PYTHON_VERSION }}" \
     --build-arg PYTHON_VERSION_ALT="{{ PYTHON_VERSION_ALT }}" \
-    --build-arg RSW_DOWNLOAD_URL="$(just _get-download-url {{OS}})" \
+    --build-arg RSW_DOWNLOAD_URL="$(just -f ../ci.Justfile _get-rsw-download-url {{RSW_RELEASE_TYPE}} {{OS}})" \
     --file=./Dockerfile.$(just -f ../Justfile _parse-os {{OS}}) .
 
 # Test Workbench image - just test rstudio/rstudio-workbench:ubuntu2204-2022.07.2-576.pro12 2022.07.2+576.pro12

--- a/workbench/maybe_install_vs_code.sh
+++ b/workbench/maybe_install_vs_code.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+major=$(echo ${RSW_VERSION} | cut -d. -f1)
+minor=$(echo ${RSW_VERSION} | cut -d. -f2)
+if [ ${major} -lt 2022 ] || [ ${major} -eq 2022 ] && [ ${minor} -lt 12 ]; then
+  echo "Installing VS Code"
+  rstudio-server install-vs-code /opt/code-server/
+  ln -s /opt/code-server/bin/code-server /usr/local/bin/code-server
+else
+  echo "VS Code is already installed"
+fi

--- a/workbench/test/goss.yaml
+++ b/workbench/test/goss.yaml
@@ -69,8 +69,14 @@ file:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+  {{ $version_split := split "." .Env.RSW_VERSION }}
+  {{ if or (lt ($version_split._0 | atoi) 2022) (and (eq ($version_split._0 | atoi) 2022) (lt ($version_split._1 | atoi) 12)) }}
+  /opt/code-server/bin/code-server:
+    exists: true
+  {{ else }}
   /usr/lib/rstudio-server/bin/code-server/bin/code-server:
     exists: true
+  {{ end }}
   /var/lib/rstudio-launcher/Local/jobs/buildkitsandbox:
     exists: false
   /etc/rstudio/vscode.conf:


### PR DESCRIPTION
* Add backwards compatibility for VS Code installation in older RSW versions
* Add option to force downloading from S3 where applicable
* Fix default tagging behavior in `workbench/Justfile`
* Use shared `_get-rsw-download-url` target in `workbench/Justfile`