### PR TITLE
update quarto

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -21,7 +21,7 @@ PYTHON_VERSION_ALT := "3.8.17"
 PYTHON_VERSION_RHEL := "3.9.14"
 PYTHON_VERSION_ALT_RHEL := "3.8.15"
 
-QUARTO_VERSION := "1.3.450"
+QUARTO_VERSION := "1.4.550"
 
 # just _get-tag-safe-version 2022.07.2+576.pro12
 _get-tag-safe-version $VERSION:

--- a/ci.Justfile
+++ b/ci.Justfile
@@ -12,7 +12,7 @@ PYTHON_VERSION_ALT := "3.8.17"
 DRIVERS_VERSION := "2023.12.1"
 DRIVERS_VERSION_RHEL := DRIVERS_VERSION + "-1"
 
-QUARTO_VERSION := "1.3.340"
+QUARTO_VERSION := "1.4.550"
 
 # just _get-os-alias jammy
 _get-os-alias OS:

--- a/connect/rstudio-connect.gcfg
+++ b/connect/rstudio-connect.gcfg
@@ -35,7 +35,7 @@ Executable = /opt/python/{{PYTHON_VERSION_ALT}}/bin/python
 
 [Quarto]
 Enabled = true
-Executable = /opt/quarto/1.3.340/bin/quarto
+Executable = /opt/quarto/1.4.550/bin/quarto
 
 [RPackageRepository "CRAN"]
 URL = https://packagemanager.rstudio.com/cran/__linux__/jammy/latest


### PR DESCRIPTION
This PR updates to the latest quarto version used in Connect so the new jumpstarts can be deployed successfully.