### PR TITLE
Add Google's GPG keyring to apt for WGCW builds

### DIFF
--- a/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2004
+++ b/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2004
@@ -32,7 +32,8 @@ ENV WORKBENCH_JUPYTER_PATH=/usr/local/bin/jupyter
 COPY deps/* /
 
 ### Update/upgrade system packages ###
-RUN apt-get update --fix-missing  \
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+    && apt-get update --fix-missing  \
     && apt-get upgrade -yq \
     && xargs -a /apt_packages.txt apt-get install -yq --no-install-recommends \
     && rm /apt_packages.txt \


### PR DESCRIPTION
Attempt to fix this failure: https://github.com/rstudio/rstudio-docker-products/actions/runs/8141490344/job/22248958138#step:8:1515