### PR TITLE
Add libarchive-dev sysdep

### DIFF
--- a/content/base/Dockerfile.ubuntu2204
+++ b/content/base/Dockerfile.ubuntu2204
@@ -39,6 +39,7 @@ RUN apt-get update \
       git \
       gsfonts \
       imagemagick \
+      libarchive-dev \
       libcairo2-dev \
       libcurl4-openssl-dev \
       libfontconfig1-dev \

--- a/product/base/Dockerfile.ubuntu2204
+++ b/product/base/Dockerfile.ubuntu2204
@@ -30,6 +30,7 @@ RUN apt-get update --fix-missing  \
         gpg-agent \
         gsfonts \
         imagemagick \
+        libarchive-dev \
         libcairo2-dev \
         libcurl4-openssl-dev \
         libev-dev \


### PR DESCRIPTION
This is important for the installation of the r-lib/archive package, which
is used by shinylive, for instance.

https://p3m.dev/client/#/repos/cran/packages/overview?search=archive