### PR TITLE
connect: enable TensorFlow Serving

### DIFF
--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,7 @@
+# 2024-05-25
+
+- Enables TensorFlow Serving.
+
 # 2024-05-24
 
 - Installs the TensorFlow Serving universal binary.

--- a/connect/rstudio-connect-float.gcfg
+++ b/connect/rstudio-connect-float.gcfg
@@ -41,6 +41,10 @@ Executable = /opt/python/{{PYTHON_VERSION_ALT}}/bin/python
 Enabled = true
 Executable = /opt/quarto/{{QUARTO_VERSION}}/bin/quarto
 
+[TensorFlow]
+Enabled = true
+Executable = /usr/bin/tensorflow_model_server
+
 ;[RPackageRepository "CRAN"]
 ;URL = https://demo.rstudiopm.com/all/__linux__/jammy/latest
 ;

--- a/connect/rstudio-connect.gcfg
+++ b/connect/rstudio-connect.gcfg
@@ -37,6 +37,10 @@ Executable = /opt/python/{{PYTHON_VERSION_ALT}}/bin/python
 Enabled = true
 Executable = /opt/quarto/{{QUARTO_VERSION}}/bin/quarto
 
+[TensorFlow]
+Enabled = true
+Executable = /usr/bin/tensorflow_model_server
+
 [RPackageRepository "CRAN"]
 URL = https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
 


### PR DESCRIPTION
Requires 2024.05.0+

May shift to a `main` merge, but for now, this targets `dev`.

Builds upon #778, which is rooted on https://github.com/rstudio/rstudio-docker-products/pull/785

Fixes #777