### PR TITLE
Fix service image Python 3.12+ issues

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -189,7 +189,7 @@ variable WORKBENCH_GOOGLE_CLOUD_WORKSTATION_BUILD_MATRIX {
 variable WORKBENCH_MICROSOFT_AZURE_ML_BUILD_MATRIX {
     default = {
         builds = [
-            {os = "ubuntu2204", r_primary = "4.4.0", r_alternate = "4.3.3", py_primary = "3.12.1", py_alternate = "3.11.7"},
+            {os = "ubuntu2204", r_primary = "4.2.3", r_alternate = "4.1.3", py_primary = "3.9.17", py_alternate = "3.8.17"},
         ]
     }
 }

--- a/product/base/scripts/ubuntu/install_python.sh
+++ b/product/base/scripts/ubuntu/install_python.sh
@@ -94,6 +94,7 @@ install_python() {
     apt-get install $APT_ARGS "/tmp/python-${PYTHON_VERSION}.deb"
     rm "/tmp/python-${PYTHON_VERSION}.deb"
     # Upgrade pip and setuptools to latest version
+    $PYTHON_BIN -m ensurepip --upgrade
     $PYTHON_BIN -m pip install -U setuptools
     $PYTHON_BIN -m pip install -U pip
 }

--- a/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
+++ b/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
@@ -59,10 +59,12 @@ RUN curl -O https://cdn.rstudio.com/python/ubuntu-2204/pkgs/python-${PYTHON_VERS
     && apt-get install -yq --no-install-recommends ./python-${PYTHON_VERSION_ALT}_1_amd64.deb \
     && rm -rf python-${PYTHON_VERSION}_1_amd64.deb \
     && rm -rf python-${PYTHON_VERSION_ALT}_1_amd64.deb \
+    && /opt/python/${PYTHON_VERSION}/bin/python3 -m ensurepip --upgrade \
     && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install 'virtualenv<20' \
     && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install --upgrade setuptools \
     && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install --upgrade pip \
     && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip cache purge \
+    && /opt/python/${PYTHON_VERSION_ALT}/bin/python3 -m ensurepip --upgrade \
     && /opt/python/${PYTHON_VERSION_ALT}/bin/python3 -m pip install 'virtualenv<20' \
     && /opt/python/${PYTHON_VERSION_ALT}/bin/python3 -m pip install --upgrade setuptools \
     && /opt/python/${PYTHON_VERSION_ALT}/bin/python3 -m pip install --upgrade pip \


### PR DESCRIPTION
Python 3.12+ has a potential issue when used with older versions of `numpy<1.26`. 

Unfortunately, WAML installs the `azureml-dataset-runtime` package which relies on an older pin of `numpy`. WAML will need to be reverted to older versions of Python to fix the issue.

WGCW also installs `numpy`, but it can be newer versions which only rely on the latest versions of `pip` and `setuptools`. 

https://stackoverflow.com/questions/77364550/attributeerror-module-pkgutil-has-no-attribute-impimporter-did-you-mean