### PR TITLE
minor fix to prevent if clause from erroring if 'getent passwd' returns a string with spaces

### DIFF
--- a/workbench/startup.sh
+++ b/workbench/startup.sh
@@ -60,7 +60,7 @@ unset RSW_LICENSE
 unset RSW_LICENSE_SERVER
 
 # Create one user
-if [ $(getent passwd $RSW_TESTUSER_UID) ] ; then
+if [ "$(getent passwd $RSW_TESTUSER_UID)" ] ; then
     echo "UID $RSW_TESTUSER_UID already exists, not creating $RSW_TESTUSER test user";
 else
     if [ -z "$RSW_TESTUSER" ]; then


### PR DESCRIPTION
The current check `if [ $(getent passwd $RSW_TESTUSER_UID) ]` in line 63 of startup.sh errors out if `RSW_TESTUSER_UID` exists and the returning string contains some spaces, e.g. 

```
root@83e35ab0ef5d:/# getent passwd ubuntu
ubuntu:x:1000:1000:AWS ParallelCluster user:/home/ubuntu:/bin/bash
root@83e35ab0ef5d:/# if [ $(getent passwd ubuntu) ]; then echo "fail"; fi
bash: [: ParallelCluster: binary operator expected
root@83e35ab0ef5d:/# if [ "$(getent passwd ubuntu)" ]; then echo "fail"; fi
fail
```

This very minor patch prevents this from happening again. 