### PR TITLE
Filter SARIF paths on images with >20 paths

### DIFF
--- a/.github/workflows/build-bake-preview.yaml
+++ b/.github/workflows/build-bake-preview.yaml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - name: Check Out main Branch
         if: github.event.schedule == '0 8 * * *'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'main'
 
@@ -104,7 +104,7 @@ jobs:
 
   connect-daily:
     needs: [versions]
-    name: Connect Image - Daily
+    name: Connect - Daily
     runs-on: ubuntu-latest-4x
 
     env:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -461,12 +461,12 @@ target "workbench-for-google-cloud-workstations" {
     tags = [
         "us-central1-docker.pkg.dev/posit-images/cloud-workstations/workbench:${tag_safe_version(WORKBENCH_VERSION)}",
         "us-central1-docker.pkg.dev/posit-images/cloud-workstations/workbench:latest",
-        "us-docker.pkg.dev/posit-images/cloud-workstations/workbench:${tag_safe_version(WORKBENCH_VERSION)}",
-        "us-docker.pkg.dev/posit-images/cloud-workstations/workbench:latest",
         "europe-docker.pkg.dev/posit-images/cloud-workstations/workbench:${tag_safe_version(WORKBENCH_VERSION)}",
         "europe-docker.pkg.dev/posit-images/cloud-workstations/workbench:latest",
         "asia-docker.pkg.dev/posit-images/cloud-workstations/workbench:${tag_safe_version(WORKBENCH_VERSION)}",
         "asia-docker.pkg.dev/posit-images/cloud-workstations/workbench:latest",
+        "us-docker.pkg.dev/posit-images/cloud-workstations/workbench:${tag_safe_version(WORKBENCH_VERSION)}",
+        "us-docker.pkg.dev/posit-images/cloud-workstations/workbench:latest",
     ]
 
     dockerfile = "Dockerfile.${builds.os}"

--- a/r-session-complete/.snyk
+++ b/r-session-complete/.snyk
@@ -11,7 +11,10 @@ ignore:
         created: 2024-07-02T20:33:30.847Z
   SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV3-6070737:
     - '*':
-        reason: 'Reported upstream in https://github.com/rstudio/openid/issues/18'
-        expires: 2024-07-31T00:00:00.000Z
-        created: 2024-07-02T20:52:24.627Z
+        reason: >-
+          Confirmed fixed upstream in
+          https://github.com/rstudio/rstudio-pro/issues/6635. Patch will be
+          ingested in Workbench 2024.08.0 (expected within 1 week).
+        expires: 2024-08-07T00:00:00.000Z
+        created: 2024-07-31T17:46:24.852Z
 patch: {}

--- a/workbench-for-google-cloud-workstations/.snyk
+++ b/workbench-for-google-cloud-workstations/.snyk
@@ -17,4 +17,9 @@ ignore:
           ingested in Workbench 2024.08.0 (expected within 1 week).
         expires: 2024-08-07T00:00:00.000Z
         created: 2024-07-31T17:46:24.852Z
+  SNYK-GOLANG-GOLANGORGXNETHTTP2-6531285:
+    - '*':
+        reason: Vulnerability in Google Cloud SDK.
+        expires: 2024-09-01T00:00:00.000Z
+        created: 2024-07-31T19:45:25.728Z
 patch: {}

--- a/workbench-for-google-cloud-workstations/.snyk
+++ b/workbench-for-google-cloud-workstations/.snyk
@@ -11,12 +11,10 @@ ignore:
         created: 2024-07-02T20:33:30.847Z
   SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV3-6070737:
     - '*':
-        reason: 'Reported upstream in https://github.com/rstudio/openid/issues/18'
-        expires: 2024-07-31T00:00:00.000Z
-        created: 2024-07-02T20:52:24.627Z
-  SNYK-GOLANG-GOLANGORGXNETHTTP2-6531285:
-    - '*':
-        reason: 'Patched in later version https://cloud.google.com/support/bulletins#gcp-2024-023'
-        expires: 2024-07-31T00:00:00.000Z
-        created: 2024-07-03T16:16:45.000Z
+        reason: >-
+          Confirmed fixed upstream in
+          https://github.com/rstudio/rstudio-pro/issues/6635. Patch will be
+          ingested in Workbench 2024.08.0 (expected within 1 week).
+        expires: 2024-08-07T00:00:00.000Z
+        created: 2024-07-31T17:46:24.852Z
 patch: {}

--- a/workbench-for-microsoft-azure-ml/.snyk
+++ b/workbench-for-microsoft-azure-ml/.snyk
@@ -11,7 +11,10 @@ ignore:
         created: 2024-07-02T20:33:30.847Z
   SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV3-6070737:
     - '*':
-        reason: 'Reported upstream in https://github.com/rstudio/openid/issues/18'
-        expires: 2024-07-31T00:00:00.000Z
-        created: 2024-07-02T20:52:24.627Z
+        reason: >-
+          Confirmed fixed upstream in
+          https://github.com/rstudio/rstudio-pro/issues/6635. Patch will be
+          ingested in Workbench 2024.08.0 (expected within 1 week).
+        expires: 2024-08-07T00:00:00.000Z
+        created: 2024-07-31T17:46:24.852Z
 patch: {}

--- a/workbench/.snyk
+++ b/workbench/.snyk
@@ -11,7 +11,10 @@ ignore:
         created: 2024-07-02T20:33:30.847Z
   SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV3-6070737:
     - '*':
-        reason: 'Reported upstream in https://github.com/rstudio/openid/issues/18'
-        expires: 2024-07-31T00:00:00.000Z
-        created: 2024-07-02T20:52:24.627Z
+        reason: >-
+          Confirmed fixed upstream in
+          https://github.com/rstudio/rstudio-pro/issues/6635. Patch will be
+          ingested in Workbench 2024.08.0 (expected within 1 week).
+        expires: 2024-08-07T00:00:00.000Z
+        created: 2024-07-31T17:46:24.852Z
 patch: {}


### PR DESCRIPTION
Closes #819

Adds filters on images with >20 paths:
- Connect (~25 paths) exclusions
  - `/opt/rstudio-connect/examples` - The content scanned is dependencies for Connect's builtin examples. It seems unnecessary to scan these since they are optional to the user and are covered upstream by Connect.
- WGCW (~58 paths) exclusions
  - `/usr/lib/google-cloud-sdk` - Files included by Google in their base image for their SDK. Managed by Google.
  - `/usr/share` - CA Certificates included by Google in their base image. Managed by Google.
  - `/usr/bin` - Various binaries included by Google such as `helm`. Managed by Google. 
  - `/usr/local/go` - Go SDK included by Google. Managed by Google.