### PR TITLE
Change Workbench home umask permissions from 0022 to 0027

### DIFF
--- a/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
+++ b/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
@@ -141,7 +141,7 @@ ADD --chmod=755 https://raw.githubusercontent.com/rstudio/wait-for-it/master/wai
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
     && chown -R rstudio-server:rstudio-server /var/lib/rstudio-server/monitor \
     && mkdir -p /startup/custom/ \
-    && printf '\n# allow home directory creation\nsession required pam_mkhomedir.so skel=/etc/skel umask=0022' >> /etc/pam.d/common-session
+    && printf '\n# allow home directory creation\nsession required pam_mkhomedir.so skel=/etc/skel umask=0027' >> /etc/pam.d/common-session
 
 COPY --chmod=755 TurboActivate.dat /opt/rstudio-license/license-manager.conf
 COPY --chmod=755 license-manager-shim /opt/rstudio-license/license-manager

--- a/workbench-for-google-cloud-workstations/pam/rstudio-session
+++ b/workbench-for-google-cloud-workstations/pam/rstudio-session
@@ -17,7 +17,7 @@ password sufficient pam_sss.so use_authtok
 password required pam_unix.so try_first_pass nullok sha512 shadow
 password optional pam_permit.so
 
-session required pam_mkhomedir.so skel=/etc/skel umask=0022
+session required pam_mkhomedir.so skel=/etc/skel umask=0027
 session required pam_env.so readenv=1
 session required pam_env.so readenv=1 envfile=/etc/default/locale
 session required pam_limits.so

--- a/workbench-for-google-cloud-workstations/test/goss.yaml
+++ b/workbench-for-google-cloud-workstations/test/goss.yaml
@@ -106,7 +106,7 @@ file:
   /etc/pam.d/common-session:
     exists: true
     contents:
-      - "/^session required pam_mkhomedir.so skel=/etc/skel umask=0022$/"
+      - "/^session required pam_mkhomedir.so skel=/etc/skel umask=0027$/"
   /etc/sssd/sssd.conf:
     exists: true
     owner: root

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -107,7 +107,7 @@ COPY conf/* /etc/rstudio/
 RUN mkdir -p /var/lib/rstudio-server/monitor/log && \
     chown -R rstudio-server:rstudio-server /var/lib/rstudio-server/monitor && \
     mkdir -p /startup/custom/ && \
-    printf '\n# allow home directory creation\nsession required pam_mkhomedir.so skel=/etc/skel umask=0022' >> /etc/pam.d/common-session
+    printf '\n# allow home directory creation\nsession required pam_mkhomedir.so skel=/etc/skel umask=0027' >> /etc/pam.d/common-session
 
 EXPOSE 8787/tcp
 EXPOSE 5559/tcp

--- a/workbench/pam/rstudio-session
+++ b/workbench/pam/rstudio-session
@@ -17,7 +17,7 @@ password sufficient pam_sss.so use_authtok
 password required pam_unix.so try_first_pass nullok sha512 shadow
 password optional pam_permit.so
 
-session required pam_mkhomedir.so skel=/etc/skel umask=0022
+session required pam_mkhomedir.so skel=/etc/skel umask=0027
 session required pam_env.so readenv=1
 session required pam_env.so readenv=1 envfile=/etc/default/locale
 session required pam_limits.so

--- a/workbench/test/goss.yaml
+++ b/workbench/test/goss.yaml
@@ -88,7 +88,7 @@ file:
   /etc/pam.d/common-session:
     exists: true
     contains:
-      - "/^session required pam_mkhomedir.so skel=/etc/skel umask=0022$/"
+      - "/^session required pam_mkhomedir.so skel=/etc/skel umask=0027$/"
   /etc/sssd/sssd.conf:
     exists: true
     owner: root


### PR DESCRIPTION
This ensures other users cannot access newly created files in someone else's home directory.