### PR TITLE
Use `--fail` flag for curl to prevent silent failures

### DIFF
--- a/connect-content-init/test/run_tests.sh
+++ b/connect-content-init/test/run_tests.sh
@@ -15,7 +15,7 @@ else
 fi
 
 # install goss to tmp location and make executable
-curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+curl -fsSL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
   && chmod +x /tmp/goss \
   && GOSS=/tmp/goss
 

--- a/connect/Dockerfile.ubuntu2204
+++ b/connect/Dockerfile.ubuntu2204
@@ -19,7 +19,7 @@ SHELL [ "/bin/bash", "-o", "pipefail", "-c"]
 
 ### Install TensorFlow Serving ###
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal" > /etc/apt/sources.list.d/tensorflow-serving.list && \
-    curl https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | apt-key add -
+    curl -fsSL https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | apt-key add -
 RUN apt-get update \
     && apt-get install -yq --no-install-recommends \
       tensorflow-model-server-universal \
@@ -34,7 +34,7 @@ RUN apt-get update --fix-missing \
       libpam-sss \
       libglib2.0-0 \
     && RSC_VERSION_URL=$(echo -n "${RSC_VERSION}" | sed 's/+/%2B/g') \
-    && curl -L -o rstudio-connect.deb "https://cdn.rstudio.com/connect/$(echo $RSC_VERSION | sed -r 's/([0-9]+\.[0-9]+).*/\1/')/rstudio-connect_${RSC_VERSION_URL}~ubuntu22_amd64.deb" \
+    && curl -fsSL -o rstudio-connect.deb "https://cdn.rstudio.com/connect/$(echo $RSC_VERSION | sed -r 's/([0-9]+\.[0-9]+).*/\1/')/rstudio-connect_${RSC_VERSION_URL}~ubuntu22_amd64.deb" \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -120,4 +120,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -120,4 +120,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"

--- a/connect/test/run_tests.sh
+++ b/connect/test/run_tests.sh
@@ -24,7 +24,7 @@ GOSS_VERSION=${GOSS_VERSION:-0.4.6}
 GOSS_MAX_CONCURRENT=${GOSS_MAX_CONCURRENT:-50}
 
 # install goss to tmp location and make executable
-curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+curl -fsSL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
   && chmod +x /tmp/goss \
   && GOSS=/tmp/goss
 

--- a/content/base/Dockerfile.ubuntu1804
+++ b/content/base/Dockerfile.ubuntu1804
@@ -77,7 +77,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update  \
     && apt-get install -y --no-install-recommends wget \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -sL "https://yihui.org/tinytex/install-bin-unix.sh" | sh \
+    && curl -fsSL "https://yihui.org/tinytex/install-bin-unix.sh" | sh \
     && /root/.TinyTeX/bin/*/tlmgr path remove \
     && mv /root/.TinyTeX/ /opt/TinyTeX \
     && /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin \

--- a/content/base/Dockerfile.ubuntu2204
+++ b/content/base/Dockerfile.ubuntu2204
@@ -86,7 +86,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update  \
     && apt-get install -y --no-install-recommends wget \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -sL "https://yihui.org/tinytex/install-bin-unix.sh" | sh \
+    && curl -fsSL "https://yihui.org/tinytex/install-bin-unix.sh" | sh \
     && /root/.TinyTeX/bin/*/tlmgr path remove \
     && mv /root/.TinyTeX/ /opt/TinyTeX \
     && /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin \
@@ -111,7 +111,7 @@ RUN curl -fsSL -O https://cdn.rstudio.com/r/${DISTRIBUTION}/pkgs/${R_INSTALLER} 
 
 # We are NOT linking one of these Python versions into the PATH.
 
-RUN curl -O https://cdn.rstudio.com/python/${DISTRIBUTION}/pkgs/python-${PYTHON_VERSION}_1_amd64.deb \
+RUN curl -fsSL -O https://cdn.rstudio.com/python/${DISTRIBUTION}/pkgs/python-${PYTHON_VERSION}_1_amd64.deb \
     && apt-get install -yq --no-install-recommends ./python-${PYTHON_VERSION}_1_amd64.deb \
     && rm -rf python-${PYTHON_VERSION}_1_amd64.deb \
     && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install --upgrade setuptools

--- a/content/base/maybe_install_quarto.sh
+++ b/content/base/maybe_install_quarto.sh
@@ -5,7 +5,7 @@
 if [[ `grep -oE bionic /etc/lsb-release` ]] && [[ `ls /opt/python/ | grep '3\.10\.'` ]] && [[ `ls /opt/R | grep '4\.1\.'` ]]; then
   qver=${QUARTO_VERSION:-1.3.340}
   echo '--> Installing Quarto'
-  curl -L -o /quarto.deb https://github.com/quarto-dev/quarto-cli/releases/download/v${qver}/quarto-${qver}-linux-amd64.deb
+  curl -fsSL -o /quarto.deb https://github.com/quarto-dev/quarto-cli/releases/download/v${qver}/quarto-${qver}-linux-amd64.deb
   apt install /quarto.deb
   rm -f /quarto.deb
 fi
@@ -14,7 +14,7 @@ fi
 if [[ `grep -oE jammy /etc/lsb-release` ]]; then
   qver=${QUARTO_VERSION:-1.3.340}
   echo '--> Installing Quarto'
-  curl -L -o /quarto.tar.gz "https://github.com/quarto-dev/quarto-cli/releases/download/v${qver}/quarto-${qver}-linux-amd64.tar.gz"
+  curl -fsSL -o /quarto.tar.gz "https://github.com/quarto-dev/quarto-cli/releases/download/v${qver}/quarto-${qver}-linux-amd64.tar.gz"
   mkdir -p /opt/quarto/${qver}
   tar -zxvf quarto.tar.gz -C "/opt/quarto/${qver}" --strip-components=1
   rm -f /quarto.tar.gz

--- a/content/pro/Dockerfile.ubuntu1804
+++ b/content/pro/Dockerfile.ubuntu1804
@@ -9,7 +9,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends unixodbc unixodbc-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -O https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb \
+RUN curl -fsSL -O https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb \
     && apt-get update \
     && apt-get install -yq --no-install-recommends ./rstudio-drivers_${DRIVERS_VERSION}_amd64.deb \
     && rm -rf /var/lib/apt/lists/* \

--- a/content/pro/Dockerfile.ubuntu2204
+++ b/content/pro/Dockerfile.ubuntu2204
@@ -9,7 +9,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends unixodbc unixodbc-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -O https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb \
+RUN curl -fsSL -O https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb \
     && apt-get update \
     && apt-get install -yq --no-install-recommends ./rstudio-drivers_${DRIVERS_VERSION}_amd64.deb \
     && rm -rf /var/lib/apt/lists/* \

--- a/float/Dockerfile.ubuntu1804
+++ b/float/Dockerfile.ubuntu1804
@@ -13,14 +13,14 @@ RUN apt-get update \
 
 # Runtime settings
 ARG TINI_VERSION=0.18.0
-RUN curl -L -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
+RUN curl -fsSL -o /usr/local/bin/tini https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini \
     && chmod +x /usr/local/bin/tini
 
 # install license server binary
 ARG PRODUCT=rsp
 ARG VERSION=1.1.2
 ARG PORT=8989
-RUN curl -L -o "${PRODUCT}-license-server.deb" "https://s3.amazonaws.com/rstudio-license-server/${PRODUCT}-license-server-${VERSION}-x86_64.deb" \
+RUN curl -fsSL -o "${PRODUCT}-license-server.deb" "https://s3.amazonaws.com/rstudio-license-server/${PRODUCT}-license-server-${VERSION}-x86_64.deb" \
     && gdebi -n ${PRODUCT}-license-server.deb \
     && rm ${PRODUCT}-license-server.deb
 

--- a/package-manager/Dockerfile.ubuntu2204
+++ b/package-manager/Dockerfile.ubuntu2204
@@ -15,7 +15,7 @@ RUN /opt/python/${PYTHON_VERSION_ALT}/bin/python3 -m pip install --no-cache-dir 
 # Download RStudio Package Manager ---------------------------------------------#
 ARG RSPM_VERSION=2024.08.0-6
 ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/deb/amd64
-RUN curl -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
+RUN curl -fsSL -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages

--- a/package-manager/test/run_tests.sh
+++ b/package-manager/test/run_tests.sh
@@ -23,7 +23,7 @@ else
 fi
 
 # install goss to tmp location and make executable
-curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+curl -fsSL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
   && chmod +x /tmp/goss \
   && GOSS=/tmp/goss
 

--- a/product/base/Dockerfile.centos7
+++ b/product/base/Dockerfile.centos7
@@ -29,7 +29,7 @@ RUN gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 595E85A6B1
 
 ### Install TinyTeX ###
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -sL "https://yihui.org/tinytex/install-bin-unix.sh" | sh \
+RUN curl -fsSL "https://yihui.org/tinytex/install-bin-unix.sh" | sh \
     && /root/.TinyTeX/bin/*/tlmgr path remove \
     && mv /root/.TinyTeX/ /opt/TinyTeX \
     && /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin \

--- a/product/base/scripts/rhel/install_drivers.sh
+++ b/product/base/scripts/rhel/install_drivers.sh
@@ -13,7 +13,7 @@ fi
 echo "$d$d Installing Professional Drivers ${DRIVERS_VERSION} $d$d"
 
 drivers_url="https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers-${DRIVERS_VERSION}.el.x86_64.rpm"
-curl -sL "$drivers_url" -o "/tmp/rstudio-drivers_${DRIVERS_VERSION}.el.x86_64.rpm"
+curl -fsSL "$drivers_url" -o "/tmp/rstudio-drivers_${DRIVERS_VERSION}.el.x86_64.rpm"
 
 yum install -y -q "/tmp/rstudio-drivers_${DRIVERS_VERSION}.el.x86_64.rpm"
 cat /opt/rstudio-drivers/odbcinst.ini.sample > /etc/odbcinst.ini

--- a/product/base/scripts/rhel/install_python.sh
+++ b/product/base/scripts/rhel/install_python.sh
@@ -92,7 +92,7 @@ install_python() {
     mkdir -p "$PREFIX"
 
     local python_url="https://cdn.rstudio.com/python/${DISTRO}-${OS_VERSION}/pkgs/python-${PYTHON_VERSION}-1-1.x86_64.rpm"
-    curl -sL "$python_url" -o "/tmp/python-${PYTHON_VERSION}.rpm"
+    curl -fsSL "$python_url" -o "/tmp/python-${PYTHON_VERSION}.rpm"
 
     # shellcheck disable=SC2086
     yum install $YUM_ARGS "/tmp/python-${PYTHON_VERSION}.rpm"

--- a/product/base/scripts/rhel/install_r.sh
+++ b/product/base/scripts/rhel/install_r.sh
@@ -98,7 +98,7 @@ install_r() {
     mkdir -p "$PREFIX"
 
     local r_url="https://cdn.rstudio.com/r/${DISTRO}-${OS_VERSION}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm"
-    curl -sL "$r_url" -o "/tmp/r-${R_VERSION}.rpm"
+    curl -fsSL "$r_url" -o "/tmp/r-${R_VERSION}.rpm"
 
     # shellcheck disable=SC2086
     yum install $YUM_ARGS "/tmp/r-${R_VERSION}.rpm"
@@ -146,7 +146,7 @@ get_r_source() {
     echo "$d Fetching R-${R_VERSION} source code into $r_source_dir $d"
     mkdir -p "$r_source_dir"
 
-    curl -sL "$r_source_url" -o "$r_source_dir/R-${R_VERSION}.tar.gz"
+    curl -fsSL "$r_source_url" -o "$r_source_dir/R-${R_VERSION}.tar.gz"
 }
 
 

--- a/product/base/scripts/ubuntu/install_drivers.sh
+++ b/product/base/scripts/ubuntu/install_drivers.sh
@@ -13,7 +13,7 @@ fi
 echo "$d$d Installing Professional Drivers ${DRIVERS_VERSION} $d$d"
 
 drivers_url="https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb"
-curl -sL "$drivers_url" -o "/tmp/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb"
+curl -fsSL "$drivers_url" -o "/tmp/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb"
 
 apt-get install -y -qq "/tmp/rstudio-drivers_${DRIVERS_VERSION}_amd64.deb"
 cat /opt/rstudio-drivers/odbcinst.ini.sample > /etc/odbcinst.ini

--- a/product/base/scripts/ubuntu/install_python.sh
+++ b/product/base/scripts/ubuntu/install_python.sh
@@ -88,7 +88,7 @@ install_python() {
     mkdir -p "$PREFIX"
 
     local python_url="https://cdn.rstudio.com/python/ubuntu-${UBUNTU_VERSION//./}/pkgs/python-${PYTHON_VERSION}_1_amd64.deb"
-    curl -sL "$python_url" -o "/tmp/python-${PYTHON_VERSION}.deb"
+    curl -fsSL "$python_url" -o "/tmp/python-${PYTHON_VERSION}.deb"
 
     # shellcheck disable=SC2086
     apt-get install $APT_ARGS "/tmp/python-${PYTHON_VERSION}.deb"

--- a/product/base/scripts/ubuntu/install_quarto.sh
+++ b/product/base/scripts/ubuntu/install_quarto.sh
@@ -87,8 +87,6 @@ while true; do
     esac
 done
 
-set -u
-
 if [ -z "$QUARTO_VERSION" ] && [[ "$IS_WORKBENCH_INSTALLATION" -eq 0 ]]; then
     usage
     exit 1

--- a/product/base/scripts/ubuntu/install_quarto.sh
+++ b/product/base/scripts/ubuntu/install_quarto.sh
@@ -103,7 +103,7 @@ install_quarto() {
     fi
 
     mkdir -p "/opt/quarto/${QUARTO_VERSION}"
-    curl -fsL "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | tar xzf - -C "/opt/quarto/${QUARTO_VERSION}" --strip-components=1
+    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | tar xzf - -C "/opt/quarto/${QUARTO_VERSION}" --strip-components=1
 }
 
 update_tinytex() {

--- a/product/base/scripts/ubuntu/install_quarto.sh
+++ b/product/base/scripts/ubuntu/install_quarto.sh
@@ -87,6 +87,8 @@ while true; do
     esac
 done
 
+set -u
+
 if [ -z "$QUARTO_VERSION" ] && [[ "$IS_WORKBENCH_INSTALLATION" -eq 0 ]]; then
     usage
     exit 1
@@ -101,7 +103,7 @@ install_quarto() {
     fi
 
     mkdir -p "/opt/quarto/${QUARTO_VERSION}"
-    wget -q -O - "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | tar xzf - -C "/opt/quarto/${QUARTO_VERSION}" --strip-components=1
+    curl -fsL "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.tar.gz" | tar xzf - -C "/opt/quarto/${QUARTO_VERSION}" --strip-components=1
 }
 
 update_tinytex() {

--- a/product/base/scripts/ubuntu/install_r.sh
+++ b/product/base/scripts/ubuntu/install_r.sh
@@ -122,7 +122,7 @@ install_r() {
     mkdir -p "$PREFIX"
 
     local r_url="https://cdn.rstudio.com/r/ubuntu-${UBUNTU_VERSION//./}/pkgs/r-${R_VERSION}_1_amd64.deb"
-    curl -sL "$r_url" -o "/tmp/r-${R_VERSION}.deb"
+    curl -fsSL "$r_url" -o "/tmp/r-${R_VERSION}.deb"
 
     # shellcheck disable=SC2086
     apt-get install $APT_ARGS "/tmp/r-${R_VERSION}.deb"
@@ -152,7 +152,7 @@ get_r_source() {
     echo "$d Fetching R-${R_VERSION} source code into $r_source_dir $d"
     mkdir -p "$r_source_dir"
 
-    curl -sL "$r_source_url" -o "$r_source_dir/R-${R_VERSION}.tar.gz"
+    curl -fsSL "$r_source_url" -o "$r_source_dir/R-${R_VERSION}.tar.gz"
 }
 
 

--- a/product/base/test/run_tests.sh
+++ b/product/base/test/run_tests.sh
@@ -19,7 +19,7 @@ else
 fi
 
 # install goss to tmp location and make executable
-curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+curl -fsSL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
   && chmod +x /tmp/goss \
   && GOSS=/tmp/goss
 

--- a/product/pro/test/run_tests.sh
+++ b/product/pro/test/run_tests.sh
@@ -19,7 +19,7 @@ else
 fi
 
 # install goss to tmp location and make executable
-curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+curl -fsSL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
   && chmod +x /tmp/goss \
   && GOSS=/tmp/goss
 

--- a/r-session-complete/Dockerfile.ubuntu2204
+++ b/r-session-complete/Dockerfile.ubuntu2204
@@ -24,7 +24,7 @@ RUN apt-get update \
       rrdtool \
       subversion \
     && RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
-    && curl -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb" \
+    && curl -fsSL -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb" \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages

--- a/r-session-complete/test/goss.yaml
+++ b/r-session-complete/test/goss.yaml
@@ -66,4 +66,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/r-session-complete/test/goss.yaml
+++ b/r-session-complete/test/goss.yaml
@@ -66,4 +66,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"

--- a/r-session-complete/test/run_tests.sh
+++ b/r-session-complete/test/run_tests.sh
@@ -12,7 +12,7 @@ else
 fi
 
 # install goss to tmp location and make executable
-curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+curl -fsSL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
   && chmod +x /tmp/goss \
   && GOSS=/tmp/goss
 

--- a/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
+++ b/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
@@ -37,7 +37,7 @@ COPY deps/* /tmp/
 
 ### Update/upgrade system packages ###
 COPY deps/apt_packages.txt /tmp/apt_packages.txt
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
     && ${SCRIPTS_DIR}/apt.sh --update upgrade \
     && ${SCRIPTS_DIR}/apt.sh install $(cat /tmp/apt_packages.txt) \
     && ${SCRIPTS_DIR}/apt.sh --clean \
@@ -79,7 +79,7 @@ RUN ${SCRIPTS_DIR}/apt.sh --update upgrade \
 
 ### Install Workbench ###
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION//+/-}-amd64.deb" \
+RUN curl -fsSL -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION//+/-}-amd64.deb" \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages
@@ -110,7 +110,7 @@ RUN rm -f /etc/rstudio/launcher.pem /etc/rstudio/launcher.pub
 # TODO(ianpittwood): Replace monitor download with $RSW_VERSION after upgrading to 2023.06.0
 RUN mkdir -p /opt/rstudio-license/ \
     && mkdir -p /var/lib/rstudio-workbench \
-    && curl -sL "https://s3.amazonaws.com/rstudio-ide-build/monitor/jammy/rsp-monitor-workbench-gcpw-amd64-${RSW_VERSION//+/-}.tar.gz" |  \
+    && curl -fsSL "https://s3.amazonaws.com/rstudio-ide-build/monitor/jammy/rsp-monitor-workbench-gcpw-amd64-${RSW_VERSION//+/-}.tar.gz" |  \
        tar xzvf - --strip 2 -C /opt/rstudio-license/ \
     && chmod 0755 /opt/rstudio-license/license-manager \
     && mv /opt/rstudio-license/license-manager /opt/rstudio-license/license-manager-orig \

--- a/workbench-for-google-cloud-workstations/test/goss.yaml
+++ b/workbench-for-google-cloud-workstations/test/goss.yaml
@@ -239,4 +239,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"

--- a/workbench-for-google-cloud-workstations/test/goss.yaml
+++ b/workbench-for-google-cloud-workstations/test/goss.yaml
@@ -239,4 +239,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench-for-google-cloud-workstations/test/run_tests.sh
+++ b/workbench-for-google-cloud-workstations/test/run_tests.sh
@@ -30,7 +30,7 @@ GOSS_VERSION=${GOSS_VERSION:-0.4.6}
 GOSS_MAX_CONCURRENT=${GOSS_MAX_CONCURRENT:-5}
 
 # install goss to tmp location and make executable
-curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+curl -fsSL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
   && chmod +x /tmp/goss \
   && GOSS=/tmp/goss
 

--- a/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
+++ b/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
@@ -39,7 +39,7 @@ RUN apt-get update --fix-missing \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update \
-    && curl -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION//+/-}-amd64.deb" \
+    && curl -fsSL -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION//+/-}-amd64.deb" \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages
@@ -51,7 +51,7 @@ RUN apt-get update \
     && rm ./rstudio-workbench.deb \
     && mkdir -p /opt/rstudio-license/ \
     && mkdir -p /var/lib/rstudio-workbench/ \
-    && curl -sL "https://s3.amazonaws.com/rstudio-ide-build/monitor/jammy/rsp-monitor-workbench-azureml-amd64-${RSW_VERSION//+/-}.tar.gz" \
+    && curl -fsSL "https://s3.amazonaws.com/rstudio-ide-build/monitor/jammy/rsp-monitor-workbench-azureml-amd64-${RSW_VERSION//+/-}.tar.gz" \
     | tar xzvf - --strip 2 -C /opt/rstudio-license/ \
     && chmod 0755 /opt/rstudio-license/license-manager \
     && mv /opt/rstudio-license/license-manager /opt/rstudio-license/license-manager-orig \
@@ -122,7 +122,7 @@ RUN /opt/python/${PYTHON_VERSION}/bin/python3 -m pip install -r /tmp/py_packages
 
 ADD --chmod=755 https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
+RUN curl -fsSL https://aka.ms/InstallAzureCLIDeb | bash \
     && az extension add -n ml -y
 
 COPY conf/* /etc/rstudio/

--- a/workbench-for-microsoft-azure-ml/deps/install-r.sh
+++ b/workbench-for-microsoft-azure-ml/deps/install-r.sh
@@ -31,7 +31,7 @@ install_r_packages() {
 
 for rvers in 4.0.5 4.1.3 4.2.3 4.3.2; do
     # install r version
-    curl -O https://cdn.rstudio.com/r/ubuntu-$(lsb_release -rs | sed 's/\.//g')/pkgs/r-${rvers}_1_amd64.deb
+    curl -fsSL -O https://cdn.rstudio.com/r/ubuntu-$(lsb_release -rs | sed 's/\.//g')/pkgs/r-${rvers}_1_amd64.deb
     DEBIAN_FRONTEND=noninteractive apt-get install -y ./r-${rvers}_1_amd64.deb
     rm -f ./r-${rvers}_1_amd64.deb
 

--- a/workbench-for-microsoft-azure-ml/test/goss.yaml
+++ b/workbench-for-microsoft-azure-ml/test/goss.yaml
@@ -157,4 +157,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"

--- a/workbench-for-microsoft-azure-ml/test/goss.yaml
+++ b/workbench-for-microsoft-azure-ml/test/goss.yaml
@@ -157,4 +157,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench-for-microsoft-azure-ml/test/run_tests.sh
+++ b/workbench-for-microsoft-azure-ml/test/run_tests.sh
@@ -31,7 +31,7 @@ GOSS_VERSION=${GOSS_VERSION:-0.4.6}
 GOSS_MAX_CONCURRENT=${GOSS_MAX_CONCURRENT:-5}
 
 # install goss to tmp location and make executable
-curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+curl -fsSL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
   && chmod +x /tmp/goss \
   && GOSS=/tmp/goss
 

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -47,7 +47,7 @@ RUN apt-get update \
       sssd \
       supervisor \
     && RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
-    && curl -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb" \
+    && curl -fsSL -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb" \
     # Pre 7/25/23 packages
     && gpg --keyserver keyserver.ubuntu.com --recv-keys 3F32EE77E331692F \
     # Post 7/25 packages
@@ -98,7 +98,7 @@ RUN /opt/python/"${PYTHON_VERSION_JUPYTER}"/bin/python -m venv /opt/python/jupyt
     && /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter \
     && /opt/python/jupyter/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
 
-RUN curl -L -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh && \
+RUN curl -fsSL -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh && \
     chmod +x /usr/local/bin/wait-for-it.sh
 
 COPY --chmod=600 sssd.conf /etc/sssd/sssd.conf

--- a/workbench/test/goss.yaml
+++ b/workbench/test/goss.yaml
@@ -154,4 +154,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench/test/goss.yaml
+++ b/workbench/test/goss.yaml
@@ -154,4 +154,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}/"

--- a/workbench/test/run_tests.sh
+++ b/workbench/test/run_tests.sh
@@ -30,7 +30,7 @@ GOSS_VERSION=${GOSS_VERSION:-0.4.6}
 GOSS_MAX_CONCURRENT=${GOSS_MAX_CONCURRENT:-5}
 
 # install goss to tmp location and make executable
-curl -sL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
+curl -fsSL https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /tmp/goss \
   && chmod +x /tmp/goss \
   && GOSS=/tmp/goss
 


### PR DESCRIPTION
- Add common `-fsSL` flags to curl usage throughout project.
- Fix Quarto tests for changes from 3-part to 2-part versions.