### PR TITLE
Security updates 2024/09

### DIFF
--- a/workbench-for-google-cloud-workstations/.snyk
+++ b/workbench-for-google-cloud-workstations/.snyk
@@ -7,19 +7,40 @@ ignore:
         reason: >-
           Reported upstream in
           https://github.com/rstudio/rstudio-pro/issues/6529
-        expires: 2024-08-31T00:00:00.000Z
+        expires: 2024-10-01T00:00:00.000Z
         created: 2024-07-02T20:33:30.847Z
   SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV3-6070737:
     - '*':
         reason: >-
           Confirmed fixed upstream in
           https://github.com/rstudio/rstudio-pro/issues/6635. Patch will be
-          ingested in Workbench 2024.08.0 (expected within 1 week).
-        expires: 2024-08-07T00:00:00.000Z
+          ingested in Workbench 2024.09.0.
+        expires: 2024-10-01T00:00:00.000Z
         created: 2024-07-31T17:46:24.852Z
-  SNYK-GOLANG-GOLANGORGXNETHTTP2-6531285:
+  SNYK-JS-WS-7266574:
     - '*':
-        reason: Vulnerability in Google Cloud SDK.
-        expires: 2024-09-01T00:00:00.000Z
-        created: 2024-07-31T19:45:25.728Z
+        reason: >-
+          VS Code usages will be patched will be ingested in Workbench
+          2024.09.0. Usages in JupyterLab are for tests and are unused in
+          Workbench releases.
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2024-08-29T16:55:08.237Z
+  SNYK-JS-BRACES-6838727:
+    - '*':
+        reason: Patch will be ingested in Workbench 2024.09.0
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2024-08-29T16:55:41.316Z
+  SNYK-JS-MICROMATCH-6838728:
+    - '*':
+        reason: Patch will be ingested in Workbench 2024.09.0
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2024-08-29T16:56:02.849Z
+  SNYK-JS-SEMVER-3247795:
+    - '*':
+        reason: >-
+          This vulnerability should be inaccessible to malicious actors and
+          should not be exploitable in its usage in JupyterLab. I would expect
+          it to be upgraded by the end of the year regardless.
+        expires: 2024-12-31T00:00:00.000Z
+        created: 2024-08-29T17:26:48.024Z
 patch: {}

--- a/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
+++ b/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
@@ -119,18 +119,10 @@ RUN mkdir -p /opt/rstudio-license/ \
 ### Install Jupyter and extensions ###
 RUN /opt/python/"${PYTHON_VERSION_JUPYTER}"/bin/python -m venv /opt/python/jupyter \
     && /opt/python/jupyter/bin/pip install \
-      jupyter \
-      jupyterlab=="${JUPYTERLAB_VERSION}" \
-      rsconnect_jupyter \
-      rsconnect_python \
-      rsp_jupyter \
-      workbench_jupyterlab \
+      jupyterlab~=4.2.4 \
+      notebook \
+      pwb_jupyterlab~=1.0 \
     && ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter \
-    && /opt/python/jupyter/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter \
     && /opt/python/jupyter/bin/python -m ipykernel install --name py${PYTHON_VERSION} --display-name "Python ${PYTHON_VERSION}" \
     && /opt/python/jupyter/bin/python -m ipykernel install --name py${PYTHON_VERSION_ALT} --display-name "Python ${PYTHON_VERSION_ALT}" \
     && /opt/python/${PYTHON_VERSION}/bin/python3 -m pip cache purge \

--- a/workbench-for-microsoft-azure-ml/.snyk
+++ b/workbench-for-microsoft-azure-ml/.snyk
@@ -7,14 +7,40 @@ ignore:
         reason: >-
           Reported upstream in
           https://github.com/rstudio/rstudio-pro/issues/6529
-        expires: 2024-08-31T00:00:00.000Z
+        expires: 2024-10-01T00:00:00.000Z
         created: 2024-07-02T20:33:30.847Z
   SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV3-6070737:
     - '*':
         reason: >-
           Confirmed fixed upstream in
           https://github.com/rstudio/rstudio-pro/issues/6635. Patch will be
-          ingested in Workbench 2024.08.0 (expected within 1 week).
-        expires: 2024-08-07T00:00:00.000Z
+          ingested in Workbench 2024.09.0.
+        expires: 2024-10-01T00:00:00.000Z
         created: 2024-07-31T17:46:24.852Z
+  SNYK-JS-WS-7266574:
+    - '*':
+        reason: >-
+          VS Code usages will be patched will be ingested in Workbench
+          2024.09.0. Usages in JupyterLab are for tests and are unused in
+          Workbench releases.
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2024-08-29T16:55:08.237Z
+  SNYK-JS-BRACES-6838727:
+    - '*':
+        reason: Patch will be ingested in Workbench 2024.09.0
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2024-08-29T16:55:41.316Z
+  SNYK-JS-MICROMATCH-6838728:
+    - '*':
+        reason: Patch will be ingested in Workbench 2024.09.0
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2024-08-29T16:56:02.849Z
+  SNYK-JS-SEMVER-3247795:
+    - '*':
+        reason: >-
+          This vulnerability should be inaccessible to malicious actors and
+          should not be exploitable in its usage in JupyterLab. I would expect
+          it to be upgraded by the end of the year regardless.
+        expires: 2024-12-31T00:00:00.000Z
+        created: 2024-08-29T17:26:48.024Z
 patch: {}

--- a/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
+++ b/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
@@ -87,22 +87,14 @@ RUN apt-get update --fix-missing -qq \
     && rm -rf /var/lib/apt/lists/*
 
 ### Install Jupyter and extensions ###
-RUN /opt/python/"${PYTHON_VERSION_JUPYTER}"/bin/python -m venv /opt/python/jupyter \
+RUN RUN /opt/python/"${PYTHON_VERSION_JUPYTER}"/bin/python -m venv /opt/python/jupyter \
     && /opt/python/jupyter/bin/pip install \
-      jupyter \
-      jupyterlab=="${JUPYTERLAB_VERSION}" \
-      rsconnect_jupyter \
-      rsconnect_python \
-      rsp_jupyter \
-      workbench_jupyterlab \
+      jupyterlab~=4.2.4 \
+      notebook \
+      pwb_jupyterlab~=1.0 \
     && /opt/python/jupyter/bin/jupyter kernelspec remove python3 -f \
     && /opt/python/jupyter/bin/pip uninstall -y ipykernel \
     && ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter \
-    && /opt/python/jupyter/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter \
     && /opt/python/${PYTHON_VERSION}/bin/pip install \
       ipykernel \
       virtualenv \

--- a/workbench/.snyk
+++ b/workbench/.snyk
@@ -7,14 +7,40 @@ ignore:
         reason: >-
           Reported upstream in
           https://github.com/rstudio/rstudio-pro/issues/6529
-        expires: 2024-08-31T00:00:00.000Z
+        expires: 2024-10-01T00:00:00.000Z
         created: 2024-07-02T20:33:30.847Z
   SNYK-GOLANG-GITHUBCOMGOJOSEGOJOSEV3-6070737:
     - '*':
         reason: >-
           Confirmed fixed upstream in
           https://github.com/rstudio/rstudio-pro/issues/6635. Patch will be
-          ingested in Workbench 2024.08.0 (expected within 1 week).
-        expires: 2024-08-07T00:00:00.000Z
+          ingested in Workbench 2024.09.0.
+        expires: 2024-10-01T00:00:00.000Z
         created: 2024-07-31T17:46:24.852Z
+  SNYK-JS-WS-7266574:
+    - '*':
+        reason: >-
+          VS Code usages will be patched will be ingested in Workbench
+          2024.09.0. Usages in JupyterLab are for tests and are unused in
+          Workbench releases.
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2024-08-29T16:55:08.237Z
+  SNYK-JS-BRACES-6838727:
+    - '*':
+        reason: Patch will be ingested in Workbench 2024.09.0
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2024-08-29T16:55:41.316Z
+  SNYK-JS-MICROMATCH-6838728:
+    - '*':
+        reason: Patch will be ingested in Workbench 2024.09.0
+        expires: 2024-10-01T00:00:00.000Z
+        created: 2024-08-29T16:56:02.849Z
+  SNYK-JS-SEMVER-3247795:
+    - '*':
+        reason: >-
+          This vulnerability should be inaccessible to malicious actors and
+          should not be exploitable in its usage in JupyterLab. I would expect
+          it to be upgraded by the end of the year regardless.
+        expires: 2024-12-31T00:00:00.000Z
+        created: 2024-08-29T17:26:48.024Z
 patch: {}

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -85,18 +85,10 @@ COPY supervisord.conf /etc/supervisor/supervisord.conf
 
 RUN /opt/python/"${PYTHON_VERSION_JUPYTER}"/bin/python -m venv /opt/python/jupyter \
     && /opt/python/jupyter/bin/pip install \
-      jupyter \
-      jupyterlab=="${JUPYTERLAB_VERSION}" \
-      rsconnect_jupyter \
-      rsconnect_python \
-      rsp_jupyter \
-      workbench_jupyterlab \
-    && ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsp_jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsp_jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension install --sys-prefix --py rsconnect_jupyter \
-    && /opt/python/jupyter/bin/jupyter-nbextension enable --sys-prefix --py rsconnect_jupyter \
-    && /opt/python/jupyter/bin/jupyter-serverextension enable --sys-prefix --py rsconnect_jupyter
+      jupyterlab~=4.2.4 \
+      notebook \
+      pwb_jupyterlab~=1.0 \
+    && ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 RUN curl -L -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh && \
     chmod +x /usr/local/bin/wait-for-it.sh


### PR DESCRIPTION
- Upgrade JupyterLab to v4+ to fix vulnerabilities related to JL 3
- Identify and list new vulnerability detections