### PR TITLE
Fix Workbench and Connect builds

### DIFF
--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -120,4 +120,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -120,4 +120,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/r-session-complete/test/goss.yaml
+++ b/r-session-complete/test/goss.yaml
@@ -66,4 +66,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"

--- a/r-session-complete/test/goss.yaml
+++ b/r-session-complete/test/goss.yaml
@@ -66,4 +66,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench-for-google-cloud-workstations/test/goss.yaml
+++ b/workbench-for-google-cloud-workstations/test/goss.yaml
@@ -239,4 +239,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench-for-google-cloud-workstations/test/goss.yaml
+++ b/workbench-for-google-cloud-workstations/test/goss.yaml
@@ -239,4 +239,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"

--- a/workbench-for-microsoft-azure-ml/test/goss.yaml
+++ b/workbench-for-microsoft-azure-ml/test/goss.yaml
@@ -157,4 +157,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench-for-microsoft-azure-ml/test/goss.yaml
+++ b/workbench-for-microsoft-azure-ml/test/goss.yaml
@@ -157,4 +157,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"

--- a/workbench/test/goss.yaml
+++ b/workbench/test/goss.yaml
@@ -154,4 +154,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench/test/goss.yaml
+++ b/workbench/test/goss.yaml
@@ -154,4 +154,4 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}\\.\\d{2}\\s+v\\d{4}\\.\\d{2}\\.\\d{2}/"
+      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?"


### PR DESCRIPTION
The Workbench and Connect builds have been failing: https://github.com/rstudio/rstudio-docker-products/actions/workflows/build-bake-preview.yaml

This is due to the regex that confirms tinytex is installed failing. Currently, this is expecting a 3 part release number, but tinytex has switched to two digit numbers: https://github.com/rstudio/tinytex-releases/releases

I kept the check for the third piece as optional to cover future releases. 