### PR TITLE
Unpin ms-python.python ext and install ms-toolsai.jupyter ext

### DIFF
--- a/r-session-complete/vscode.extensions.conf
+++ b/r-session-complete/vscode.extensions.conf
@@ -1,4 +1,5 @@
 quarto.quarto
 REditorSupport.r@2.8.2
-ms-python.python@2023.6.1
+ms-python.python
 posit.shiny
+ms-toolsai.jupyter


### PR DESCRIPTION
We need a newer version of `ms-python.python` for compatibility with new `pwb-code-server`. This change unpins the extension and will install the latest available.

Also adding `ms-toolsai.jupyter` for compatibility with JupyterNotebook based tests in VSCode.

This should address failures seen in Workbench Automation: https://github.com/rstudio/rstudio-pro/issues/6731