### PR TITLE
fix: update downloads.json to point to posit.co

### DIFF
--- a/tools/get-version.py
+++ b/tools/get-version.py
@@ -108,7 +108,7 @@ def download_json(url):
 
 
 def get_downloads_json():
-    return download_json("https://www.rstudio.com/wp-content/downloads.json")
+    return download_json("https://posit.co/wp-content/uploads/downloads.json")
 
 
 def rstudio_workbench_preview():


### PR DESCRIPTION
The `downloads.json` file on rstudio.com seems to have disappeared, causing the GHA that pushes new Docker tags to fail:
https://github.com/rstudio/rstudio-docker-products/actions

This PR updates the URL to point to the `downloads.json` on posit.co. I tested that the four uses of `downloads.json` return valid responses to make sure this file was in the same format:
```
$ curl https://posit.co/wp-content/uploads/downloads.json | jq -r ".rstudio.pro.stable.version"
2024.04.2+764.pro1
$ curl https://posit.co/wp-content/uploads/downloads.json | jq -r ".connect.installer.focal.version"
2024.08.0
$ curl https://posit.co/wp-content/uploads/downloads.json | jq -r ".rspm.installer.focal.version"
2024.08.0-6
$ curl https://posit.co/wp-content/uploads/downloads.json | jq -r ".rstudio.pro.preview.version"
2024.04.2+764.pro1
```