### PR TITLE
Stop writing launcher debug logs to container

### DIFF
--- a/workbench-for-google-cloud-workstations/conf/launcher.conf
+++ b/workbench-for-google-cloud-workstations/conf/launcher.conf
@@ -4,7 +4,6 @@ port=5559
 server-user=rstudio-server
 admin-group=rstudio-server
 authorization-enabled=1
-enable-debug-logging=1
 
 [cluster]
 name=Local

--- a/workbench-for-microsoft-azure-ml/conf/launcher.conf
+++ b/workbench-for-microsoft-azure-ml/conf/launcher.conf
@@ -5,7 +5,6 @@ server-user=rstudio-server
 admin-group=rstudio-server
 authorization-enabled=1
 thread-pool-size=4
-enable-debug-logging=1
 
 [cluster]
 name=Local

--- a/workbench/conf/launcher.conf
+++ b/workbench/conf/launcher.conf
@@ -5,7 +5,6 @@ server-user=rstudio-server
 admin-group=rstudio-server
 authorization-enabled=1
 thread-pool-size=4
-enable-debug-logging=1
 
 [cluster]
 name=Local


### PR DESCRIPTION
Additional debug logging can be enabled through logging.conf if required
