### PR TITLE
Upgrade pip and setuptools on Jupyter venv creation

### DIFF
--- a/r-session-complete/Dockerfile.ubuntu2204
+++ b/r-session-complete/Dockerfile.ubuntu2204
@@ -44,6 +44,8 @@ RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 RUN $SCRIPTS_DIR/install_quarto.sh --install-tinytex --add-path-tinytex
 
 RUN /opt/python/"${PYTHON_VERSION}"/bin/python -m venv /opt/python/jupyter \
+    && /opt/python/jupyter/bin/python -m pip install --upgrade pip \
+    && /opt/python/jupyter/bin/python -m pip install --upgrade setuptools \
     && /opt/python/jupyter/bin/python -m pip install \
       jupyterlab~=4.2.4 \
       notebook \

--- a/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
+++ b/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
@@ -118,6 +118,8 @@ RUN mkdir -p /opt/rstudio-license/ \
 
 ### Install Jupyter and extensions ###
 RUN /opt/python/"${PYTHON_VERSION_JUPYTER}"/bin/python -m venv /opt/python/jupyter \
+    && /opt/python/jupyter/bin/python -m pip install --upgrade pip \
+    && /opt/python/jupyter/bin/python -m pip install --upgrade setuptools \
     && /opt/python/jupyter/bin/python -m pip install\
       jupyterlab~=4.2.4 \
       notebook \

--- a/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
+++ b/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
@@ -88,6 +88,8 @@ RUN apt-get update --fix-missing -qq \
 
 ### Install Jupyter and extensions ###
 RUN /opt/python/"${PYTHON_VERSION_JUPYTER}"/bin/python -m venv /opt/python/jupyter \
+    && /opt/python/jupyter/bin/python -m pip install --upgrade pip \
+    && /opt/python/jupyter/bin/python -m pip install --upgrade setuptools \
     && /opt/python/jupyter/bin/pip install \
       jupyterlab~=4.2.4 \
       notebook \

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -80,6 +80,8 @@ COPY startup/* /startup/base/
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 
 RUN /opt/python/"${PYTHON_VERSION_JUPYTER}"/bin/python -m venv /opt/python/jupyter \
+    && /opt/python/jupyter/bin/python -m pip install --upgrade pip \
+    && /opt/python/jupyter/bin/python -m pip install --upgrade setuptools \
     && /opt/python/jupyter/bin/python -m pip install \
       jupyterlab~=4.2.4 \
       notebook \


### PR DESCRIPTION
Patches CVE-2024-6345 and CVE-2022-40897

This should prevent future issues with out-of-date setuptools being bundled in the Jupyter virtual environment.