### PR TITLE
Update build-manual.yaml

### DIFF
--- a/.github/workflows/build-manual.yaml
+++ b/.github/workflows/build-manual.yaml
@@ -141,6 +141,8 @@ jobs:
             product="CONNECT"
           elif [[ "$product" == "package-manager" ]]; then
             product="PACKAGE_MANAGER"
+          elif [[ "$product" == "workbench-session-init" ]]; then
+            product="WORKBENCH_SESSION_INIT"
           else
             product="WORKBENCH"
           fi


### PR DESCRIPTION
Adds the WORKBENCH_SESSION_INIT variable to the manual build flow so that we can trigger a release candidate build of the Workbench session init container image to test with.