### PR TITLE
ci: update readme path for content-base and content-pro dockerhub repos

### DIFF
--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -20,8 +20,8 @@ jobs:
           - {prefix: 'rstudio-', repository: 'workbench', readme_path: './workbench/README.md'}
           - {prefix: 'rstudio-', repository: 'connect', readme_path: './connect/README.md'}
           - {prefix: 'rstudio-', repository: 'connect-content-init', readme_path: './connect-content-init/README.md'}
-          - {prefix: '', repository: 'content-base', readme_path: './content/base/README.md'}
-          - {prefix: '', repository: 'content-pro', readme_path: './content/pro/README.md'}
+          - {prefix: '', repository: 'content-base', readme_path: './content/README.md'}
+          - {prefix: '', repository: 'content-pro', readme_path: './content/README.md'}
           - {prefix: 'rstudio-', repository: 'package-manager', readme_path: './package-manager/README.md'}
           - {prefix: '', repository: 'r-session-complete', readme_path: './r-session-complete/README.md'}
           - {prefix: 'rstudio-', repository: 'workbench-for-microsoft-azure-ml', readme_path: './workbench-for-microsoft-azure-ml/README.md'}


### PR DESCRIPTION
Relates to #894

`content/base/README.md` and `content/pro/README.md` files no longer exist, so this change updates the update-readme workflow to use the `content/README.md` file for the dockerhub repository description for the `content-base` and `content-pro` images.

The intent of this change is to fix the `no such file or directory` error, which is one of the two errors causing the update-readme workflow to fail.

The next step to get the update-readme workflow to run successfully is to ensure the dockerhub access token that is used by the `peter-evans/dockerhub-description` github actions has the `read/write/delete` scope.