### PR TITLE
Add strace and gdb to r-session-complete

### DIFF
--- a/r-session-complete/Dockerfile.ubuntu2204
+++ b/r-session-complete/Dockerfile.ubuntu2204
@@ -16,12 +16,14 @@ ENV WORKBENCH_JUPYTER_PATH=/usr/local/bin/jupyter
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
+      gdb \
       krb5-user \
       libcurl4-gnutls-dev \
       libuser \
       libuser1-dev \
       libpq-dev \
       rrdtool \
+      strace \
       subversion \
     && RSW_VERSION_URL=$(echo -n "${RSW_VERSION}" | sed 's/+/-/g') \
     && curl -fsSL -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_VERSION_URL}-amd64.deb" \


### PR DESCRIPTION
Mirrors #892, but [per guidance from Posit Support](https://github.com/rstudio/rstudio-docker-products/pull/892#issuecomment-2652164413), adding to the session, instead of server, image.

Supercedes #899

Closes #887
