### PR TITLE
Fix permissions errors when calling TinyTeX packages from `pandoc`

### DIFF
--- a/connect/Dockerfile.ubuntu2204
+++ b/connect/Dockerfile.ubuntu2204
@@ -12,7 +12,7 @@ ARG QUARTO_VERSION=1.4.557
 ARG SCRIPTS_DIR=/opt/positscripts
 
 ### Install Quarto ###
-RUN QUARTO_VERSION=${QUARTO_VERSION} ${SCRIPTS_DIR}/install_quarto.sh --install-tinytex --add-path-tinytex \
+RUN QUARTO_VERSION=${QUARTO_VERSION} ${SCRIPTS_DIR}/install_quarto.sh \
     && ln -s /opt/quarto/${QUARTO_VERSION}/bin/quarto /usr/local/bin/quarto
 
 SHELL [ "/bin/bash", "-o", "pipefail", "-c"]
@@ -45,6 +45,13 @@ RUN apt-get update --fix-missing \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+### Install TinyTeX ###
+# TODO: Remove this once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
+RUN quarto install tinytex \
+    && mv /root/.TinyTeX /opt/TinyTeX \
+    && chmod -R 755 /opt/TinyTeX \
+    && /opt/TinyTeX/bin/x86_64-linux/tlmgr option sys_bin /usr/local/bin \
+    && /opt/TinyTeX/bin/x86_64-linux/tlmgr path add
 
 ### Configure Connect ###
 EXPOSE 3939/tcp

--- a/connect/Dockerfile.ubuntu2204
+++ b/connect/Dockerfile.ubuntu2204
@@ -12,7 +12,8 @@ ARG QUARTO_VERSION=1.4.557
 ARG SCRIPTS_DIR=/opt/positscripts
 
 ### Install Quarto ###
-RUN QUARTO_VERSION=${QUARTO_VERSION} ${SCRIPTS_DIR}/install_quarto.sh \
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
+RUN HOME="/opt" QUARTO_VERSION=${QUARTO_VERSION} ${SCRIPTS_DIR}/install_quarto.sh --install-tinytex --add-path-tinytex \
     && ln -s /opt/quarto/${QUARTO_VERSION}/bin/quarto /usr/local/bin/quarto
 
 SHELL [ "/bin/bash", "-o", "pipefail", "-c"]
@@ -44,14 +45,6 @@ RUN apt-get update --fix-missing \
     && rm -rf ./rstudio-connect.deb \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-### Install TinyTeX ###
-# TODO: Remove this once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
-RUN quarto install tinytex \
-    && mv /root/.TinyTeX /opt/TinyTeX \
-    && chmod -R 755 /opt/TinyTeX \
-    && /opt/TinyTeX/bin/x86_64-linux/tlmgr option sys_bin /usr/local/bin \
-    && /opt/TinyTeX/bin/x86_64-linux/tlmgr path add
 
 ### Configure Connect ###
 EXPOSE 3939/tcp

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,8 +1,9 @@
 # 2025-03-10
 
-- Quarto installations of TinyTeX are manually moved from `/root` to `/opt` to prevent potential permissions issues
-  when running Quarto in a non-root user context. TinyTeX's tools will still be linked to `/usr/local/bin` which should
-  prevent this from being a breaking change.
+- Quarto TinyTeX installation path has been updated from `/root/.TinyTeX` to `/opt/.TinyTeX` to fix potential permission 
+  issues when called from a non-root user. As a result, Quarto will no longer recognize TinyTeX as a managed 
+  installation. This change is not expected to affect the existing functionality of Quarto or TinyTeX for end users.
+  TinyTeX's relevant packages will still be linked to `/usr/local/bin` as before.
 
 # 2024-05-30
 

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,9 @@
+# 2025-03-10
+
+- Quarto installations of TinyTeX are manually moved from `/root` to `/opt` to prevent potential permissions issues
+  when running Quarto in a non-root user context. TinyTeX's tools will still be linked to `/usr/local/bin` which should
+  prevent this from being a breaking change.
+
 # 2024-05-30
 
 - BREAKING:

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -146,10 +146,12 @@ command:
     title: quarto_check
     exit-status: 0
 
-# TODO: Reenable this once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
+
 # Ensure TinyTeX is installed
-#  "quarto list tools":
-#    title: quarto_tinytex_installed
-#    exit-status: 0
-#    stderr:
+  "quarto list tools":
+    title: quarto_tinytex_installed
+    exit-status: 0
+    stderr:
+      - "/tinytex\\s+External Installation/"
+# TODO: Reenable this once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
 #      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -14,6 +14,9 @@ package:
     installed: true
   cracklib-runtime:
     installed: true
+  # Necessary for `tlmgr` to work properly
+  perl:
+    installed: true
 
 port:
   tcp6:3939:
@@ -49,6 +52,34 @@ file:
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+  /opt/TinyTeX:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/TinyTeX/bin/x86_64-linux/tlmgr:
+    exists: true
+    filetype: symlink
+    mode: "0777"
+    linked-to: ../../texmf-dist/scripts/texlive/tlmgr.pl
+  /opt/TinyTeX/bin/x86_64-linux/tex:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/TinyTeX/bin/x86_64-linux/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: pdftex
+    mode: "0777"
+  /usr/local/bin/tex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/TinyTeX/bin/x86_64-linux/tex
+    mode: "0777"
+  /usr/local/bin/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/TinyTeX/bin/x86_64-linux/pdflatex
+    mode: "0777"
   /tmp/startup.log:
     exists: true
     contents:
@@ -115,9 +146,10 @@ command:
     title: quarto_check
     exit-status: 0
 
+# TODO: Reenable this once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
 # Ensure TinyTeX is installed
-  "quarto list tools":
-    title: quarto_tinytex_installed
-    exit-status: 0
-    stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"
+#  "quarto list tools":
+#    title: quarto_tinytex_installed
+#    exit-status: 0
+#    stderr:
+#      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -52,20 +52,20 @@ file:
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
-  /opt/TinyTeX:
+  /opt/.TinyTeX:
     exists: true
     filetype: directory
     mode: "0755"
-  /opt/TinyTeX/bin/x86_64-linux/tlmgr:
+  /opt/.TinyTeX/bin/x86_64-linux/tlmgr:
     exists: true
     filetype: symlink
     mode: "0777"
     linked-to: ../../texmf-dist/scripts/texlive/tlmgr.pl
-  /opt/TinyTeX/bin/x86_64-linux/tex:
+  /opt/.TinyTeX/bin/x86_64-linux/tex:
     exists: true
     filetype: file
     mode: "0755"
-  /opt/TinyTeX/bin/x86_64-linux/pdflatex:
+  /opt/.TinyTeX/bin/x86_64-linux/pdflatex:
     exists: true
     filetype: symlink
     linked-to: pdftex
@@ -73,12 +73,12 @@ file:
   /usr/local/bin/tex:
     exists: true
     filetype: symlink
-    linked-to: /opt/TinyTeX/bin/x86_64-linux/tex
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/tex
     mode: "0777"
   /usr/local/bin/pdflatex:
     exists: true
     filetype: symlink
-    linked-to: /opt/TinyTeX/bin/x86_64-linux/pdflatex
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/pdflatex
     mode: "0777"
   /tmp/startup.log:
     exists: true

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -70,6 +70,10 @@ file:
     filetype: symlink
     linked-to: pdftex
     mode: "0777"
+  /opt/.TinyTeX/bin/x86_64-linux/pdftex:
+    exists: true
+    filetype: file
+    mode: "0755"
   /usr/local/bin/tex:
     exists: true
     filetype: symlink


### PR DESCRIPTION
This fixes a bug reported by a customer where `pandoc` throws a permissions error when using a TinyTeX package in the Connect image. The cause of the issue is that `quarto install tinytex` always installs to `$HOME/.TinyTeX`. Image builds that run as `root` will install TinyTeX to `/root/.TinyTeX`, a location inaccessible to non-root users. An issue for modifying the behavior of Quarto's TinyTeX install path already exists in https://github.com/quarto-dev/quarto-cli/issues/11800. I have created a minimal content reproduction of a scenario where this issue can occur [here](https://github.com/rstudio/jumpstart_examples/tree/f44955ee0438b7563c1887efaba769257f48b62f/bundles/generate-report-pdf-shiny) to use with existing image builds based on one of the available [Shiny examples](https://github.com/rstudio/shiny-examples/tree/main/112-generate-report).

Changes:
- Prefix the Quarto installation with `HOME="/opt"` to trick Quarto into installing TinyTeX to `/opt/.TinyTeX`. This will make TinyTeX and its packages globally read/execute accessible.
- Update Goss tests to check
  - `perl` is installed as it is required for `tlmgr` to work.
  - TinyTeX install directory exists and is in `/opt`.
  - Existence/permissions on a few expected TinyTeX binaries. `pdflatex` and its links are specifically checked as it was the one reported for this bug.
  - Symlinks exist as expected in `/usr/local/bin` for TinyTeX.
  - Quarto identifies TinyTeX as an "External Installation".
- Added note in `NEWS.md` about the change, though I do not expect it to change the behavior of currently functional content deployments.