### PR TITLE
Fix TinyTeX permissions on Workbench images

### DIFF
--- a/r-session-complete/Dockerfile.ubuntu2204
+++ b/r-session-complete/Dockerfile.ubuntu2204
@@ -22,6 +22,7 @@ RUN apt-get update \
       libuser \
       libuser1-dev \
       libpq-dev \
+      perl \
       rrdtool \
       strace \
       subversion \
@@ -43,7 +44,7 @@ RUN apt-get update \
 RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 
 ### Install TinyTeX using Quarto ###
-RUN $SCRIPTS_DIR/install_quarto.sh --install-tinytex --add-path-tinytex
+RUN HOME="/opt" $SCRIPTS_DIR/install_quarto.sh --install-tinytex --add-path-tinytex
 
 RUN /opt/python/"${PYTHON_VERSION}"/bin/python -m venv /opt/python/jupyter \
     && /opt/python/jupyter/bin/python -m pip install --upgrade pip \

--- a/r-session-complete/NEWS.md
+++ b/r-session-complete/NEWS.md
@@ -1,3 +1,10 @@
+# 2025.03.11
+
+- Quarto TinyTeX installation path has been updated from `/root/.TinyTeX` to `/opt/.TinyTeX` to fix potential permission 
+  issues when called from a non-root user. As a result, Quarto will no longer recognize TinyTeX as a managed 
+  installation. This change is not expected to affect the existing functionality of Quarto or TinyTeX for end users.
+  TinyTeX's relevant packages will still be linked to `/usr/local/bin` as before.
+
 # 2023.03.1
 - Update Python VSCode extension to version 2023.6.1
 

--- a/r-session-complete/test/goss.yaml
+++ b/r-session-complete/test/goss.yaml
@@ -1,3 +1,8 @@
+package:
+  # Necessary for `tlmgr` to work properly
+  perl:
+    installed: true
+
 file:
   /usr/lib/rstudio-server:
     exists: true
@@ -21,6 +26,38 @@ file:
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+  /opt/.TinyTeX:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/.TinyTeX/bin/x86_64-linux/tlmgr:
+    exists: true
+    filetype: symlink
+    mode: "0777"
+    linked-to: ../../texmf-dist/scripts/texlive/tlmgr.pl
+  /opt/.TinyTeX/bin/x86_64-linux/tex:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/.TinyTeX/bin/x86_64-linux/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: pdftex
+    mode: "0777"
+  /opt/.TinyTeX/bin/x86_64-linux/pdftex:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /usr/local/bin/tex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/tex
+    mode: "0777"
+  /usr/local/bin/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/pdflatex
+    mode: "0777"
 
 command:
   "echo '{ \"cells\": [], \"metadata\": {}, \"nbformat\": 4, \"nbformat_minor\": 2}' | /opt/python/jupyter/bin/jupyter nbconvert --to notebook --stdin --stdout":
@@ -66,4 +103,6 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"
+      - "/tinytex\\s+External Installation/"
+# TODO: Reenable this once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
+#      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
+++ b/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
@@ -100,7 +100,7 @@ RUN curl -fsSL -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_V
 RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 
 ### Install TinyTeX using Quarto ###
-RUN $SCRIPTS_DIR/install_quarto.sh --install-tinytex --add-path-tinytex
+RUN HOME="/opt" $SCRIPTS_DIR/install_quarto.sh --install-tinytex --add-path-tinytex
 
 # Workaround to ensure no pre-generated certificates are included in image distributions.
 # This happens in the step immediately following Workbench installation in case the certificates are generated.

--- a/workbench-for-google-cloud-workstations/test/goss.yaml
+++ b/workbench-for-google-cloud-workstations/test/goss.yaml
@@ -23,6 +23,9 @@ package:
     installed: true
     versions:
     - {{.Env.DRIVERS_VERSION}}
+  # Necessary for `tlmgr` to work properly
+  perl:
+    installed: true
 
 port:
   tcp:80:
@@ -151,6 +154,38 @@ file:
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+  /opt/.TinyTeX:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/.TinyTeX/bin/x86_64-linux/tlmgr:
+    exists: true
+    filetype: symlink
+    mode: "0777"
+    linked-to: ../../texmf-dist/scripts/texlive/tlmgr.pl
+  /opt/.TinyTeX/bin/x86_64-linux/tex:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/.TinyTeX/bin/x86_64-linux/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: pdftex
+    mode: "0777"
+  /opt/.TinyTeX/bin/x86_64-linux/pdftex:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /usr/local/bin/tex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/tex
+    mode: "0777"
+  /usr/local/bin/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/pdflatex
+    mode: "0777"
 
 
 command:
@@ -242,4 +277,6 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"
+      - "/tinytex\\s+External Installation/"
+# TODO: Reenable this once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
+#      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
+++ b/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
@@ -69,7 +69,7 @@ RUN rm -f /etc/rstudio/launcher.pem /etc/rstudio/launcher.pub
 RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 
 ### Install TinyTeX using Quarto ###
-RUN $SCRIPTS_DIR/install_quarto.sh --install-tinytex --add-path-tinytex
+RUN HOME="/opt" $SCRIPTS_DIR/install_quarto.sh --install-tinytex --add-path-tinytex
 
 COPY --chmod=0755 license-manager-shim /opt/rstudio-license/license-manager
 COPY --chmod=0775 startup.sh /usr/local/bin/startup.sh

--- a/workbench-for-microsoft-azure-ml/NEWS.md
+++ b/workbench-for-microsoft-azure-ml/NEWS.md
@@ -1,3 +1,10 @@
+# 2025.03.11
+
+- Quarto TinyTeX installation path has been updated from `/root/.TinyTeX` to `/opt/.TinyTeX` to fix potential permission 
+  issues when called from a non-root user. As a result, Quarto will no longer recognize TinyTeX as a managed 
+  installation. This change is not expected to affect the existing functionality of Quarto or TinyTeX for end users.
+  TinyTeX's relevant packages will still be linked to `/usr/local/bin` as before.
+
 # 2024.02.1
 - Remove R 3.6.3 from image
 - Bump R versions to latest patches

--- a/workbench-for-microsoft-azure-ml/deps/apt_packages.txt
+++ b/workbench-for-microsoft-azure-ml/deps/apt_packages.txt
@@ -13,6 +13,7 @@ libxext6
 libxrender1
 oddjob-mkhomedir
 openssh-client
+perl
 rrdtool
 sssd
 supervisor

--- a/workbench-for-microsoft-azure-ml/test/goss.yaml
+++ b/workbench-for-microsoft-azure-ml/test/goss.yaml
@@ -21,6 +21,9 @@ group:
 package:
   rstudio-server:
     installed: true
+  # Necessary for `tlmgr` to work properly
+  perl:
+    installed: true
   # test all system packages
   {{range .Vars.syspkgs}}
   {{.}}:
@@ -92,6 +95,38 @@ file:
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+  /opt/.TinyTeX:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/.TinyTeX/bin/x86_64-linux/tlmgr:
+    exists: true
+    filetype: symlink
+    mode: "0777"
+    linked-to: ../../texmf-dist/scripts/texlive/tlmgr.pl
+  /opt/.TinyTeX/bin/x86_64-linux/tex:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/.TinyTeX/bin/x86_64-linux/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: pdftex
+    mode: "0777"
+  /opt/.TinyTeX/bin/x86_64-linux/pdftex:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /usr/local/bin/tex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/tex
+    mode: "0777"
+  /usr/local/bin/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/pdflatex
+    mode: "0777"
 
 command:
   "su rstudio-server -c 'touch /var/lib/rstudio-server/monitor/log/rstudio-server.log'":
@@ -160,4 +195,6 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"
+      - "/tinytex\\s+External Installation/"
+# TODO: Reenable this once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
+#      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -73,7 +73,7 @@ RUN rm -f /etc/rstudio/launcher.pem /etc/rstudio/launcher.pub
 RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 
 ### Install TinyTeX using Quarto ###
-RUN $SCRIPTS_DIR/install_quarto.sh --install-tinytex --add-path-tinytex
+RUN HOME="/opt" $SCRIPTS_DIR/install_quarto.sh --install-tinytex --add-path-tinytex
 
 COPY --chmod=0775 startup.sh /usr/local/bin/startup.sh
 COPY startup-launcher/* /startup/launcher/

--- a/workbench/NEWS.md
+++ b/workbench/NEWS.md
@@ -1,3 +1,10 @@
+# 2025.03.11
+
+- Quarto TinyTeX installation path has been updated from `/root/.TinyTeX` to `/opt/.TinyTeX` to fix potential permission 
+  issues when called from a non-root user. As a result, Quarto will no longer recognize TinyTeX as a managed 
+  installation. This change is not expected to affect the existing functionality of Quarto or TinyTeX for end users.
+  TinyTeX's relevant packages will still be linked to `/usr/local/bin` as before.
+
 # 2024.09.0
 
 - Update umask for user home directory from 0022 to 0077 to improve security of directory permissions

--- a/workbench/test/goss.yaml
+++ b/workbench/test/goss.yaml
@@ -12,6 +12,9 @@ group:
 package:
   rstudio-server:
     installed: true
+  # Necessary for `tlmgr` to work properly
+  perl:
+    installed: true
 
 port:
   tcp:8787:
@@ -94,6 +97,38 @@ file:
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+  /opt/.TinyTeX:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/.TinyTeX/bin/x86_64-linux/tlmgr:
+    exists: true
+    filetype: symlink
+    mode: "0777"
+    linked-to: ../../texmf-dist/scripts/texlive/tlmgr.pl
+  /opt/.TinyTeX/bin/x86_64-linux/tex:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/.TinyTeX/bin/x86_64-linux/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: pdftex
+    mode: "0777"
+  /opt/.TinyTeX/bin/x86_64-linux/pdftex:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /usr/local/bin/tex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/tex
+    mode: "0777"
+  /usr/local/bin/pdflatex:
+    exists: true
+    filetype: symlink
+    linked-to: /opt/.TinyTeX/bin/x86_64-linux/pdflatex
+    mode: "0777"
 
 command:
   "su rstudio-server -c 'touch /var/lib/rstudio-server/monitor/log/rstudio-server.log'":
@@ -151,4 +186,6 @@ command:
     title: quarto_tinytex_installed
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"
+      - "/tinytex\\s+External Installation/"
+# TODO: Reenable this once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
+#      - "/tinytex\\s+Up to date\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?\\s+v\\d{4}\\.\\d{2}(\\.\\d{2})?/"


### PR DESCRIPTION
This fixes a potential bug where calls to tools like `pandoc` or `rmarkdown` by non-root processes where a TinyTeX package is called will throw a permissions error. This is similar to the behavior described in #904. `quarto install tinytex` always installs to `$HOME/.TinyTeX` with no way to change the install path via the Quarto CLI. This means that our current install process, which runs as `root`, will install TinyTeX to `/root/.TinyTeX` making TinyTeX and its packages inaccessible to non-root users. An issue for modifying the behavior of Quarto's TinyTeX install path already exists in https://github.com/quarto-dev/quarto-cli/issues/11800.

Changes:
- Prefix Quarto installation with `HOME="/opt"` to trick Quarto into install TinyTeX to `/opt/.TinyTeX`. This will make TinyTeX and its packages globally read/execute accessible.
- Update Goss tests to check
  - `perl` is installed as it is required for `tlmgr` to work.
  - TinyTeX install directory exists and is in `/opt`.
  - Existence/permissions on a few expected TinyTeX binaries. `pdflatex` and its links are specifically checked as it was the one reported for this bug.
  - Symlinks exist as expected in `/usr/local/bin` for TinyTeX.
  - Quarto identifies TinyTeX as an "External Installation".
- Added note in `NEWS.md` about the change, though I do not expect it to change the behavior of currently functional content deployments.