### PR TITLE
Remove bin/node from pwb init deps

### DIFF
--- a/workbench-session-init/entrypoint/main.go
+++ b/workbench-session-init/entrypoint/main.go
@@ -52,7 +52,6 @@ var (
 	sessionDeps = map[string][]string{
 		"jupyter": {
 			"bin/jupyter-session-run",
-			"bin/node",
 			"extras",
 		},
 		"positron": {
@@ -61,7 +60,6 @@ var (
 			"extras",
 		},
 		"rstudio": {
-			"bin/node",
 			"bin/rsession-run",
 		},
 		"vscode": {

--- a/workbench-session-init/test/goss.yaml
+++ b/workbench-session-init/test/goss.yaml
@@ -11,3 +11,96 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+  # Should encompass commonDeps and sessionDeps listed in main.go
+  /opt/session-components/bin/git-credential-pwb:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/session-components/bin/focal:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/jammy:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/noble:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/opensuse15:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/postback:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/pwb-supervisor:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/session-components/bin/quarto:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/r-ldpath:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/session-components/bin/rhel8:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/rhel9:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/shared-run:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/session-components/R:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/resources:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/www:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/www-symbolmaps:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/jupyter-session-run:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/session-components/extras:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/positron-server:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/positron-session-run:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/session-components/bin/rsession-run:
+    exists: true
+    filetype: file
+    mode: "0755"
+  /opt/session-components/bin/pwb-code-server:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/vscode-session-run:
+    exists: true
+    filetype: file
+    mode: "0755"


### PR DESCRIPTION
As of https://github.com/rstudio/rstudio-pro/commit/9171cb058328bf5c8cdfae073661e252101ffb31, node is no longer included as a standalone dep in our session components. This PR removes it from the dependency list to prevent copy failures.

I also added to the goss tests to explicitly check for each file/directory dependency we have a hard check for in the Go code so that hopefully we can catch removed dependencies earlier in the future.