### PR TITLE
Support for adhoc copies.

### DIFF
--- a/workbench-session-init/entrypoint/main.go
+++ b/workbench-session-init/entrypoint/main.go
@@ -28,15 +28,19 @@ var (
 		NumOfWorkers:      20,
 	}
 
-	// List of dependencies common to all session types
+	// List of dependencies common to all environments
 	commonDeps = []string{
+		"bin/pwb-supervisor",
+	}
+
+	// List of dependencies common to all session types
+	commonSessionDeps = append([]string{
 		"bin/git-credential-pwb",
 		"bin/focal",
 		"bin/jammy",
 		"bin/noble",
 		"bin/opensuse15",
 		"bin/postback",
-		"bin/pwb-supervisor",
 		"bin/quarto",
 		"bin/r-ldpath",
 		"bin/rhel8",
@@ -46,27 +50,30 @@ var (
 		"resources",
 		"www",
 		"www-symbolmaps",
-	}
+	}, commonDeps...)
 
 	// Map of session-specific dependencies
 	sessionDeps = map[string][]string{
-		"jupyter": {
+		"jupyter": append([]string{
 			"bin/jupyter-session-run",
+			"bin/node",
 			"extras",
-		},
-		"positron": {
+		}, commonSessionDeps...),
+		"positron": append([]string{
 			"bin/positron-server",
 			"bin/positron-session-run",
 			"extras",
-		},
-		"rstudio": {
+		}, commonSessionDeps...),
+		"rstudio": append([]string{
+			"bin/node",
 			"bin/rsession-run",
-		},
-		"vscode": {
+		}, commonSessionDeps...),
+		"vscode": append([]string{
 			"bin/pwb-code-server",
 			"bin/vscode-session-run",
 			"extras",
-		},
+		}, commonSessionDeps...),
+		"adhoc": commonDeps,
 	}
 )
 
@@ -104,13 +111,11 @@ func main() {
 
 // getFilesToCopy returns the list of files to copy based on the session type.
 func getFilesToCopy(sessionType string) ([]string, error) {
-	files := commonDeps
 	if deps, ok := sessionDeps[sessionType]; ok {
-		files = append(files, deps...)
+		return deps, nil
 	} else {
 		return nil, fmt.Errorf("unknown session type: %s", sessionType)
 	}
-	return files, nil
 }
 
 // validateTargetDir checks if the target directory exists and is empty.

--- a/workbench-session-init/entrypoint/main_test.go
+++ b/workbench-session-init/entrypoint/main_test.go
@@ -16,22 +16,27 @@ func TestGetFilesToCopy(t *testing.T) {
 	}{
 		{
 			sessionType: "jupyter",
-			expected:    append(commonDeps, sessionDeps["jupyter"]...),
+			expected:    sessionDeps["jupyter"],
 			expectError: false,
 		},
 		{
 			sessionType: "positron",
-			expected:    append(commonDeps, sessionDeps["positron"]...),
+			expected:    sessionDeps["positron"],
 			expectError: false,
 		},
 		{
 			sessionType: "rstudio",
-			expected:    append(commonDeps, sessionDeps["rstudio"]...),
+			expected:    sessionDeps["rstudio"],
 			expectError: false,
 		},
 		{
 			sessionType: "vscode",
-			expected:    append(commonDeps, sessionDeps["vscode"]...),
+			expected:    sessionDeps["vscode"],
+			expectError: false,
+		},
+		{
+			sessionType: "adhoc",
+			expected:    commonDeps,
 			expectError: false,
 		},
 		{


### PR DESCRIPTION
This is a companion PR to add adhoc job support for init containers.

Ok this is the same PR as over here: https://github.com/rstudio/rstudio-docker-products/pull/913

But this one is branched from dev instead of main.