### PR TITLE
Remove node.

### DIFF
--- a/workbench-session-init/entrypoint/main.go
+++ b/workbench-session-init/entrypoint/main.go
@@ -56,7 +56,6 @@ var (
 	sessionDeps = map[string][]string{
 		"jupyter": append([]string{
 			"bin/jupyter-session-run",
-			"bin/node",
 			"extras",
 		}, commonSessionDeps...),
 		"positron": append([]string{
@@ -65,7 +64,6 @@ var (
 			"extras",
 		}, commonSessionDeps...),
 		"rstudio": append([]string{
-			"bin/node",
 			"bin/rsession-run",
 		}, commonSessionDeps...),
 		"vscode": append([]string{


### PR DESCRIPTION
We don't actually package node anymore - so this ends up erroring when used,

```
Copying files from /opt/session-components to /mnt/init
error copying /opt/session-components/bin/node: lstat /opt/session-components/bin/node: no such file or directory
```