### PR TITLE
Add copilot-language-server to workbench-session-init

### DIFF
--- a/workbench-session-init/entrypoint/main.go
+++ b/workbench-session-init/entrypoint/main.go
@@ -56,6 +56,7 @@ var (
 		}, commonSessionDeps...),
 		"rstudio": append([]string{
 			"bin/rsession-run",
+			"bin/copilot-language-server",
 		}, commonSessionDeps...),
 		"vscode": append([]string{
 			"bin/pwb-code-server",

--- a/workbench-session-init/test/goss.yaml
+++ b/workbench-session-init/test/goss.yaml
@@ -104,3 +104,7 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+  /opt/session-components/bin/copilot-language-server/copilot-language-server:
+    exists: true
+    filetype: file
+    mode: "0755"


### PR DESCRIPTION
Addresses rstudio/rstudio-pro#7773 for K8s setups that use init containers.
