### PR TITLE
Remove focal from workbench init container

### DIFF
--- a/workbench-session-init/entrypoint/main.go
+++ b/workbench-session-init/entrypoint/main.go
@@ -27,7 +27,6 @@ var (
 	// List of dependencies common to all session types
 	commonSessionDeps = append([]string{
 		"bin/git-credential-pwb",
-		"bin/focal",
 		"bin/jammy",
 		"bin/noble",
 		"bin/opensuse15",


### PR DESCRIPTION
We're no longer building or publishing focal builds, so this PR removes that expected path from the session components.