### PR TITLE
Don't special-case workbench-session-init in the manual build

### DIFF
--- a/.github/workflows/build-manual.yaml
+++ b/.github/workflows/build-manual.yaml
@@ -141,8 +141,6 @@ jobs:
             product="CONNECT"
           elif [[ "$product" == "package-manager" ]]; then
             product="PACKAGE_MANAGER"
-          elif [[ "$product" == "workbench-session-init" ]]; then
-            product="WORKBENCH_SESSION_INIT"
           else
             product="WORKBENCH"
           fi


### PR DESCRIPTION
This PR removes the special case for manually building workbench-session-init, since it produces an environment variable `WORKBENCH_SESSION_INIT_<TYPE>_VERSION` which is not used by any of the bake targets, which actually just expect `WORKBENCH_<TYPE>_VERSION` like the other workbench-related image targets.

## Broken Build

https://github.com/rstudio/rstudio-docker-products/actions/runs/15305976326

## Fixed Build (run from this PR branch)

https://github.com/rstudio/rstudio-docker-products/actions/runs/15308025160