### PR TITLE
connect: do not use activate-file

### DIFF
--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,8 @@
+# 2025-06-03
+
+- Install a license file using file copies rather than `license-manager activate-file`.
+- Run `license-manager deactivate` only when using license keys or license servers.
+
 # 2025-03-10
 
 - Quarto TinyTeX installation path has been updated from `/root/.TinyTeX` to `/opt/.TinyTeX` to fix potential permission 

--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -27,16 +27,19 @@ deactivate() {
       done
     done
 }
-trap deactivate EXIT
 
 # Activate License
 RSC_LICENSE_FILE_PATH=${RSC_LICENSE_FILE_PATH:-/etc/rstudio-connect/license.lic}
 if ! [ -z "$RSC_LICENSE" ]; then
     /opt/rstudio-connect/bin/license-manager activate $RSC_LICENSE
+    trap deactivate EXIT
 elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
+    trap deactivate EXIT
 elif test -f "$RSC_LICENSE_FILE_PATH"; then
-    /opt/rstudio-connect/bin/license-manager activate-file $RSC_LICENSE_FILE_PATH
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${RSC_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod g-rwx,g-rwx /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes


### PR DESCRIPTION
Remove any existing license files, copy the license file into `/var/lib/rstudio-connect`, and use less open permissions.

This essentially mirrors how Connect recommends license file installation and avoids using `license-manager activate-file`, which requires root.