### PR TITLE
Enhancements to license file documentation and link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Note you must have a license in place, and all other instructions in separate se
 If you have created an image you want to use yourself, you can push to your own image repository system. The images are
 named `rstudio-workbench`, `rstudio-connect`, and `rstudio-package-manager`.
 
-# Licensing
+# License
 
 The license associated with the RStudio Docker Products repository is
 located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).

--- a/connect-content-init/NEWS.md
+++ b/connect-content-init/NEWS.md
@@ -1,3 +1,7 @@
+# 2025-07-03
+
+- Update README.md links and information for Dockerhub.
+
 # 2023-07-12
 
 - BREAKING: Deprecate the Ubuntu 18.04 (Bionic Beaver) images.

--- a/connect-content-init/README.md
+++ b/connect-content-init/README.md
@@ -10,7 +10,7 @@
 
 * [`jammy`, `ubuntu2204`, `jammy-2025.06.0`, `ubuntu2204-2025.06.0`](https://github.com/rstudio/rstudio-docker-products/blob/main/connect/Dockerfile.2204)
 
-# RStudio Connect Content Init Container
+# Posit Connect Content Init Container
 
 This container is intended for use as an "init container" to pull
 runtime components into another container, which can then be used with Connect and
@@ -24,7 +24,7 @@ Connect Helm chart. Additional information about the Helm chart can be found in 
 
 # License
 
-The license associated with the RStudio Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
+The license associated with the Posit Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
 
 As is the case with all container images, the images themselves also contain other software which may be under other
 licenses (i.e. bash, linux, system libraries, etc., along with any other direct or indirect dependencies of the primary

--- a/connect-content-init/README.md
+++ b/connect-content-init/README.md
@@ -1,11 +1,10 @@
-**PRE-RELEASE - DO NOT USE**
-
 # Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
-* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues)
-* RStudio Connect image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect)
-* RStudio Connect Content Init image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect-content-init)
+* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), [the Posit Connect Documentation](https://docs.posit.co/connect/), 
+  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/posit-connect/27), or [Posit Support](https://support.posit.co/hc/en-us)
+* Posit Connect image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect), [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-connect)
+* Posit Connect Content Init image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect-content-init), [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-connect-content-init)
 
 # Supported tags and respective Dockerfile links
 
@@ -13,55 +12,17 @@
 
 # RStudio Connect Content Init Container
 
-This directory contains a Dockerfile and script that will create a "copy
-container" to copy runtime components from a release package into a target
-mount directory. This container can be used as an "init container" to pull the
-runtime components into another image, which can then be used with Connect and
-Launcher to build/run content.
+This container is intended for use as an "init container" to pull
+runtime components into another container, which can then be used with Connect and
+Launcher to build/run content. This container [can be extended to include additional
+content](https://docs.posit.co/helm/examples/connect/container-images/custom-images.html)
+beyond what is provided by default.
 
-## Building
+This image is primarily used in Kubernetes deployments and is leveraged by the Posit 
+Connect Helm chart. Additional information about the Helm chart can be found in the
+[Posit Connect Helm Chart documentation](https://docs.posit.co/helm/charts/rstudio-connect/README.html).
 
-Just will build an image using a default Connect distribution.
-
-```console
-just build
-```
-
-The version of the release package to use can be overridden with the
-`RSC_VERSION` build arg.
-
-```console
-just build ubuntu2204 2025.06.0
-```
-
-## Testing
-
-You can observe what gets copied by the container:
-
-```console
-mkdir rstudio-connect-runtime
-docker run --rm -v $(pwd)/rstudio-connect-runtime:/mnt/rstudio-connect-runtime rstudio/rstudio-connect-content-init-preview:1.8.8.3-dev236
-# The rstudio-connect-runtime directory has been populated with the Connect
-# runtime components.
-```
-
-You can also test using goss:
-```console
-just test
-```
-
-
-## Inspection
-
-You can see the different layers that make up the image:
-
-```console
-docker history rstudio/rstudio-connect-content-init-preview:2025.06.0-dev-326
-```
-
-NOTE: almost all the image size is pandoc.
-
-# Licensing
+# License
 
 The license associated with the RStudio Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
 

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,8 @@
+# 2025-07-03
+
+- Update documentation with additional license file usage instructions.
+- Add startup message for when a license file is found in `/var/lib/rstudio-connect/*.lic`.
+
 # 2025-06-03
 
 - Install a license file using file copies rather than `license-manager activate-file`.

--- a/connect/README.md
+++ b/connect/README.md
@@ -74,8 +74,9 @@ This container includes:
 
 1. Two versions of R
 2. Two versions of Python
-3. Posit Professional Drivers
-4. Posit Connect
+3. Quarto
+4. Posit Professional Drivers
+5. Posit Connect
 
 Note that running the Posit Connect Docker image requires the container to run using the `--privileged` flag and a
 valid Posit Connect license.

--- a/connect/README.md
+++ b/connect/README.md
@@ -113,7 +113,7 @@ docker run -it --privileged \
 
 ### Product Licensing
 
-Using the Posit Connect docker image requires to have a valid License. You can set the license in three ways:
+Using the Posit Connect docker image requires to have a valid License. You can set the license three different ways:
 
 1. Setting the `RSC_LICENSE` environment variable to a valid license key inside the container
 2. Setting the `RSC_LICENSE_SERVER` environment variable to a valid license server / port inside the container
@@ -131,6 +131,17 @@ for activation if present. This example uses a bind mount to provide the license
 docker run -it --privileged \
     -p 3939:3939 \
     --mount type=bind,ro,src=<path to license file>,dst=/var/lib/rstudio-connect/rstudio-connect.lic \
+    rstudio/rstudio-connect:ubuntu2204
+```
+
+Alternatively, the license file's path in the container can be provided using the `RSC_LICENSE_FILE_PATH` environment 
+variable. If provided, the container will attempt to find and activate from the file at the given path.
+
+```bash
+docker run -it --privileged \
+    -p 3939:3939 \
+    -e RSC_LICENSE_FILE_PATH=/opt/license.lic \
+    --mount type=bind,ro,src=<path to license file>,dst=/opt/license.lic \
     rstudio/rstudio-connect:ubuntu2204
 ```
 

--- a/connect/README.md
+++ b/connect/README.md
@@ -220,16 +220,16 @@ details on license key issues.
 
 ### Environment variables
 
-| Variable | Description | Default |
-|-----|---|---|
-| `RSC_LICENSE` | License key for Posit Connect, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX` | None |
-| `RSC_LICENSE_SERVER` | Floating license server, format should be: `my.url.com:port` | None |
+| Variable             | Description                                                                           | Default |
+|----------------------|---------------------------------------------------------------------------------------|---------|
+| `RSC_LICENSE`        | License key for Posit Connect, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX` | None    |
+| `RSC_LICENSE_SERVER` | Floating license server, format should be: `my.url.com:port`                          | None    |
 
 ### Ports
 
-| Variable | Description |
-|-----|---|
-| `3939` | Default HTTP Port for Posit Connect |
+| Variable | Description                         |
+|----------|-------------------------------------|
+| `3939`   | Default HTTP Port for Posit Connect |
 
 ## Caveats of product licensing in containers
 

--- a/connect/README.md
+++ b/connect/README.md
@@ -1,9 +1,10 @@
 # Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
-* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues)
-* Posit Connect image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect)
-* Posit Connect Content Init image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect-content-init)
+* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), [the Posit Connect Documentation](https://docs.posit.co/connect/), 
+  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/posit-connect/27), or [Posit Support](https://support.posit.co/hc/en-us)
+* Posit Connect image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect), [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-connect)
+* Posit Connect Content Init image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect-content-init), [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-connect-content-init)
 
 # Supported tags and respective Dockerfile links
 
@@ -41,7 +42,7 @@ https://posit.co/products/enterprise/connect/.
 
 # How to use this image
 
-Below is a very simple example for running Connect locally in Docker.
+Below is a very simple example for running Connect locally in Docker using a product license key.
 ```bash
 # Replace with valid license
 export RSC_LICENSE=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
@@ -97,20 +98,105 @@ See a complete example of that file at `connect/rstudio-connect.gcfg`.
 In order to persist Connect metadata and app data between container restarts configure the Connect `Server.DataDir` 
 option to go to a persistent volume. 
 
-The included configuration file expects a persistent volume from the host machine or your docker
-orchestration system to be available at `/data`. Should you wish to move this to a different path, you can change the
-`Server.DataDir` option.
+The included configuration file expects a persistent volume from the host machine or your docker orchestration system to
+be available at `/data`. Should you wish to move this to a different path, you can change the `Server.DataDir` option.
 
-### Licensing
+Below is an example of running the Posit Connect container with a bind mount attached to the `/data` directory.
+
+```bash
+docker run -it --privileged \
+    -p 3939:3939 \
+    -e RSC_LICENSE=$RSC_LICENSE \
+    --mount type=bind,src=/path/to/local/directory,dst=/data \
+    rstudio/rstudio-connect:ubuntu2204
+```
+
+### Product Licensing
 
 Using the Posit Connect docker image requires to have a valid License. You can set the license in three ways:
 
 1. Setting the `RSC_LICENSE` environment variable to a valid license key inside the container
 2. Setting the `RSC_LICENSE_SERVER` environment variable to a valid license server / port inside the container
-3. Mounting a `/etc/rstudio-connect/license.lic` single file that contains a valid license for Posit Connect
+3. Mounting a `/var/lib/rstudio-connect/*.lic` single file that contains a valid license for Posit Connect
 
-**NOTE:** the "offline activation process" is not supported by this image today. Offline installations will need
-to explore using a license server, license file, or custom image with manual intervention.
+**NOTE:** Offline installations will need to use a floating license server, license file, or custom image with manual 
+intervention to successfully activate the instance.
+
+#### Example usage with a license file
+
+The container will automatically look for a license file at `/var/lib/rstudio-connect/*.lic` and will attempt to use it
+for activation if present. This example uses a bind mount to provide the license file from the host machine.
+
+```bash
+docker run -it --privileged \
+    -p 3939:3939 \
+    --mount type=bind,ro,src=<path to license file>,dst=/var/lib/rstudio-connect/rstudio-connect.lic \
+    rstudio/rstudio-connect:ubuntu2204
+```
+
+If the license file does not successfully activate, the container should fail to start under most circumstances. You can
+still verify the container's licensing status by running the `status` command against the `license-manager` binary.
+
+```bash
+$ docker exec -it <container name> /opt/rstudio-connect/bin/license-manager status
+TTY detected. Printing informational message about logging configuration. Logging configuration loaded from '/etc/rstudio/logging.conf'. Logging to '/var/log/rstudio/rstudio-server/license-manager.log'.
+RStudio License Manager 2024.04.2+764.pro1
+
+-- License file status --
+
+Status: Activated
+Product-Key: XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
+Has-Key: Yes
+Has-Trial: No
+Tier: Tier Name
+SKU-Year: 2024
+Enable-Launcher: 1
+Users: 0
+User-Activity-Days: 365
+Shiny-Users: 0
+Allow-APIs: 1
+Anonymous-Servers: 0
+Unrestricted-Servers: 0
+Licensee: Company Name
+License-File: /var/lib/rstudio-connect/rstudio-connect.lic
+Expiration: YYYY-MM-DD HH:mm:ss
+Days-Left: XXX
+License-Engine: 1.0.0.0
+License-Scope: System
+
+-- Local license status --
+
+Trial-Type: Verified
+Status: Expired
+Has-Key: No
+Has-Trial: Yes
+License-Scope: System
+License-Engine: 4.4.3.0
+
+-- Floating license status --
+
+License server not in use.
+```
+
+#### Example usage with a license key
+
+The container can also be activated using a license key by setting the `RSC_LICENSE` environment variable. 
+
+```bash
+# Replace with valid license
+export RSC_LICENSE=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
+
+# Run without persistent data and using an external configuration
+docker run -it --privileged \
+    -p 3939:3939 \
+    -e RSC_LICENSE=$RSC_LICENSE \
+    rstudio/rstudio-connect:ubuntu2204
+```
+
+If possible, license key activation should be avoided in production environments in favor of using a license file due to 
+the risk of leaking license activations when the container is not gracefully stopped. See the 
+[caveats of product licensing in containers](#caveats-of-product-licensing-in-containers) section below for more 
+details on license key issues.
 
 ### Environment variables
 
@@ -124,30 +210,6 @@ to explore using a license server, license file, or custom image with manual int
 | Variable | Description |
 |-----|---|
 | `3939` | Default HTTP Port for Posit Connect |
-
-### Example usage
-
-```bash
-# Replace with valid license
-export RSC_LICENSE=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
-
-# Run without persistent data and using an external configuration
-docker run -it --privileged \
-    -p 3939:3939 \
-    -v $PWD/connect/rstudio-connect.gcfg:/etc/rstudio-connect/rstudio-connect.gcfg \
-    -e RSC_LICENSE=$RSC_LICENSE \
-    rstudio/rstudio-connect:ubuntu2204
-
-# Run with persistent data and using an external configuration
-docker run -it --privileged \
-    -p 3939:3939 \
-    -v $PWD/data/rsc:/data \
-    -v $PWD/connect/rstudio-connect.gcfg:/etc/rstudio-connect/rstudio-connect.gcfg \
-    -e RSC_LICENSE=$RSC_LICENSE \
-    rstudio/rstudio-connect:ubuntu2204
-```
-
-Open [http://localhost:3939](http://localhost:3939) to access Posit Connect.
 
 ## Caveats of product licensing in containers
 
@@ -186,7 +248,7 @@ into issues with your license, please do not hesitate to [contact Posit support]
 While neither of these solutions will eliminate the problem, they should help mitigate it. We are still investigating a 
 long-term solution.
 
-# Licensing
+# License
 The license associated with the Posit Docker Products repository is located 
 [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
 

--- a/connect/README.md
+++ b/connect/README.md
@@ -1,10 +1,14 @@
 # Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
-* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), [the Posit Connect Documentation](https://docs.posit.co/connect/), 
-  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/posit-connect/27), or [Posit Support](https://support.posit.co/hc/en-us)
-* Posit Connect image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect), [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-connect)
-* Posit Connect Content Init image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect-content-init), [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-connect-content-init)
+* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 
+  [the Posit Connect Documentation](https://docs.posit.co/connect/),
+  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/posit-connect/27), 
+  or [Posit Support](https://support.posit.co/hc/en-us)
+* Posit Connect image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect), 
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-connect)
+* Posit Connect Content Init image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-connect-content-init), 
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-connect-content-init)
 
 # Supported tags and respective Dockerfile links
 
@@ -37,7 +41,11 @@ https://posit.co/products/enterprise/connect/.
    changes. We
    provide [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) for
    these cases.
-1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version 
+   was released/updated. They should be reviewed and updated before production use. If your organization has a specific 
+   set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the 
+   [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal 
+   security standards.
 
 
 # How to use this image
@@ -88,7 +96,8 @@ Be sure the config file has these fields:
 - `Server.Address` set to the exact URL that users will use to visit Connect. A
   placeholder `http://localhost:3939` is in use by default
 - `Server.DataDir` set to `/data/`
-- `HTTP.Listen` (or equivalent `HTTP`, `HTTPS`, or `HTTPRedirect` settings. This could change how you should configure the container ports)
+- `HTTP.Listen` (or equivalent `HTTP`, `HTTPS`, or `HTTPRedirect` settings. This could change how you should configure 
+  the container ports)
 - `Python.Enabled` and `Python.Executable`
 
 See a complete example of that file at `connect/rstudio-connect.gcfg`.

--- a/connect/README.md
+++ b/connect/README.md
@@ -61,7 +61,7 @@ docker run -it --privileged \
     -e RSC_LICENSE=$RSC_LICENSE \
     rstudio/rstudio-connect:ubuntu2204
 ```
-Once running, open [http://localhost:3939](http://localhost:3939) to access RStudio Connect.
+Once running, open [http://localhost:3939](http://localhost:3939) to access Posit Connect.
 
 ## Overview
 

--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -36,12 +36,11 @@ if ! [ -z "$RSC_LICENSE" ]; then
 elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
     trap deactivate EXIT
+elif test -f "$RSC_LICENSE_FILE_PATH"; then
+    rm -f /var/lib/rstudio-connect/*.lic || true
+    /opt/rstudio-connect/bin/license-manager activate-file $RSC_LICENSE_FILE_PATH
 elif ls /var/lib/rstudio-connect/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-connect/*.lic."
-elif test -f "$RSC_LICENSE_FILE_PATH"; then
-    rm -f /var/lib/rstudio-connect/*.lic
-    cp "${RSC_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
-    chmod g-rwx,g-rwx /var/lib/rstudio-connect/license.lic
 fi
 
 # ensure these cannot be inherited by child processes

--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -36,6 +36,8 @@ if ! [ -z "$RSC_LICENSE" ]; then
 elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
     trap deactivate EXIT
+elif ls /var/lib/rstudio-connect/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in /var/lib/rstudio-connect/*.lic."
 elif test -f "$RSC_LICENSE_FILE_PATH"; then
     rm -f /var/lib/rstudio-connect/*.lic
     cp "${RSC_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
@@ -45,6 +47,7 @@ fi
 # ensure these cannot be inherited by child processes
 unset RSC_LICENSE
 unset RSC_LICENSE_SERVER
+unset RSC_LICENSE_FILE_PATH
 
 # Start RStudio Connect
 /opt/rstudio-connect/bin/connect --config /etc/rstudio-connect/rstudio-connect.gcfg

--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -37,8 +37,9 @@ elif ! [ -z "$RSC_LICENSE_SERVER" ]; then
     /opt/rstudio-connect/bin/license-manager license-server $RSC_LICENSE_SERVER
     trap deactivate EXIT
 elif test -f "$RSC_LICENSE_FILE_PATH"; then
-    rm -f /var/lib/rstudio-connect/*.lic || true
-    /opt/rstudio-connect/bin/license-manager activate-file $RSC_LICENSE_FILE_PATH
+    rm -f /var/lib/rstudio-connect/*.lic
+    cp "${RSC_LICENSE_FILE_PATH}" /var/lib/rstudio-connect/license.lic
+    chmod g-rwx,g-rwx /var/lib/rstudio-connect/license.lic
 elif ls /var/lib/rstudio-connect/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-connect/*.lic."
 fi

--- a/package-manager/NEWS.md
+++ b/package-manager/NEWS.md
@@ -1,3 +1,10 @@
+# 2025-07-03
+
+- Update documentation with additional license file usage instructions.
+- Replace usage of `license-manager activate-file` with file copies for installing license files per PPM admin guide.
+- Add startup message for when a license file is found in `/var/lib/rstudio-connect/*.lic` or 
+  `/home/rstudio-pm/.rstudio-pm/*.lic`.
+
 # 2025-06-05
 - Update PPM to v2025.04.2
 

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -14,7 +14,7 @@
 
 # What is Posit Package Manager?
 
-Posit Package Manager, formerly Posit Package Manager, is a repository management server to organize and centralize
+Posit Package Manager, formerly RStudio Package Manager, is a repository management server to organize and centralize
 R packages across your team, department, or entire organization. Get offline access to CRAN, automate CRAN syncs,
 share local packages, restrict package access, find packages across repositories, and more. Experience reliable and
 consistent package management, optimized for teams who use R.

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -1,9 +1,12 @@
 # Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
-* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), [the Posit Package Manager Documentation](https://docs.posit.co/rspm/), 
-  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/package-manager/21), or [Posit Support](https://support.posit.co/hc/en-us)
-* RStudio Package Manager image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-package-manager), [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-package-manager)
+* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 
+  [the Posit Package Manager Documentation](https://docs.posit.co/rspm/), 
+  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/package-manager/21), 
+  or [Posit Support](https://support.posit.co/hc/en-us)
+* RStudio Package Manager image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-package-manager), 
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-package-manager)
 
 # Supported tags and respective Dockerfile links
 
@@ -31,9 +34,13 @@ consistent package management, optimized for teams who use R.
 1. The Package Manager image uses the `No Sandbox` option documented
    [here](https://docs.rstudio.com/rspm/admin/process-management/#process-management-sandboxing) by default, if you need
    a more secure option for configuring
-   [Git-related package builds](https://docs.rstudio.com/rspm/admin/building-packages/) we recommend [using a system with
-   sandboxing enabled](https://docs.rstudio.com/rspm/admin/process-management/#docker).
-1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
+   [Git-related package builds](https://docs.rstudio.com/rspm/admin/building-packages/) we recommend [using a system 
+   with sandboxing enabled](https://docs.rstudio.com/rspm/admin/process-management/#docker).
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version 
+   was released/updated. They should be reviewed and updated before production use. If your organization has a specific 
+   set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the 
+   [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal 
+   security standards.
 
 
 # How to use this image
@@ -77,8 +84,8 @@ Be sure the config file has the `HTTP.Listen` field configured. See a complete e
 
 In order to persist Package Manager data between container restarts, configure the `Server.DataDir` option to go to
 a persistent volume. The included configuration file expects a persistent volume from the host machine or your docker
-orchestration system to be available at `/var/lib/rstudio-pm`. Should you wish to move this to a different path, you can change the
-`Server.DataDir` option.
+orchestration system to be available at `/var/lib/rstudio-pm`. Should you wish to move this to a different path, you can 
+change the `Server.DataDir` option.
 
 ```ini
 [Server]
@@ -91,7 +98,8 @@ Using the container requires a valid license for Posit Package Manager. You can 
 
 1. Setting the `RSPM_LICENSE` environment variable to a valid license key inside the container
 2. Setting the `RSPM_LICENSE_SERVER` environment variable to a valid license server / port inside the container
-3. Mounting a license file at `/var/lib/rstudio-pm/*.lic` or a different path specified using `RSPM_LICENSE_FILE_PATH` that contains a valid license for RStudio Package Manager
+3. Mounting a license file at `/var/lib/rstudio-pm/*.lic` or a different path specified using `RSPM_LICENSE_FILE_PATH`
+   that contains a valid license for RStudio Package Manager
 
 **NOTE:** the "offline activation process" is not supported by this image today. Offline installations will need
 to explore using a license server, license file, or custom image with manual intervention.

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -101,8 +101,8 @@ Using the container requires a valid license for Posit Package Manager. You can 
 3. Mounting a license file at `/var/lib/rstudio-pm/*.lic` or a different path specified using `RSPM_LICENSE_FILE_PATH`
    that contains a valid license for Posit Package Manager
 
-**NOTE:** the "offline activation process" is not supported by this image today. Offline installations will need
-to explore using a license server, license file, or custom image with manual intervention.
+**NOTE:** Offline installations will need to use a floating license server, license file, or custom image with manual 
+intervention to successfully activate the instance.
 
 #### Example usage with a license file
 

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -193,15 +193,15 @@ details on license key issues.
 
 ### Environment variables
 
-| Variable | Description | Default |
-|-----|---|---|
-| `RSPM_LICENSE` | License key for Posit Package Manager, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX` | None |
-| `RSPM_LICENSE_SERVER` | Floating license server, format should be: `my.url.com:port` | None |
+| Variable              | Description                                                                                   | Default |
+|-----------------------|-----------------------------------------------------------------------------------------------|---------|
+| `RSPM_LICENSE`        | License key for Posit Package Manager, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX` | None    |
+| `RSPM_LICENSE_SERVER` | Floating license server, format should be: `my.url.com:port`                                  | None    |
 
 ### Ports
 
-| Variable | Description |
-|----------|---|
+| Variable | Description                                 |
+|----------|---------------------------------------------|
 | `4242`   | Default HTTP Port for Posit Package Manager |
 
 ### Example usage

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -106,8 +106,9 @@ intervention to successfully activate the instance.
 
 #### Example usage with a license file
 
-The container will automatically look for a license file at `/var/lib/rstudio-pm/*.lic` and will attempt to use it
-for activation if present. This example uses a bind mount to provide the license file from the host machine.
+The container will automatically look for a license file at `/var/lib/rstudio-pm/*.lic` or 
+`/home/rstudio-pm/.rstudio-pm/*.lic` and will attempt to use it for activation if present. This example uses a bind 
+mount to provide the license file from the host machine.
 
 ```bash
 docker run -it --privileged \
@@ -130,6 +131,9 @@ docker run -it --privileged \
 If the license file does not successfully activate, the container should fail to start under most circumstances. You can
 still verify the container's licensing status by running the `status` command against the `license-manager` binary.
 
+Depending on how the license file was provided, the `License-File` field may be `/var/lib/rstudio-pm/*.lic` or
+`/home/rstudio-pm/.rstudio-pm/*.lic`. Either path should work so long as the `Status` field shows `Activated`.
+
 ```bash
 $ docker exec -it <container name> /opt/rstudio-pm/bin/license-manager status
 TTY detected. Printing informational message about logging configuration. Logging configuration loaded from '/etc/rstudio/logging.conf'. Logging to '/var/log/rstudio/rstudio-server/license-manager.log'.
@@ -151,7 +155,7 @@ Allow-APIs: 1
 Anonymous-Servers: 0
 Unrestricted-Servers: 0
 Licensee: Company Name
-License-File: /var/lib/rstudio-pm/rstudio-pm.lic
+License-File: /home/rstudio-pm/.rstudio-pm/rstudio-pm.lic
 Expiration: YYYY-MM-DD HH:mm:ss
 Days-Left: XXX
 License-Engine: 1.0.0.0

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -1,8 +1,9 @@
 # Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
-* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues)
-* RStudio Package Manager image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-package-manager)
+* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), [the Posit Package Manager Documentation](https://docs.posit.co/rspm/), 
+  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/package-manager/21), or [Posit Support](https://support.posit.co/hc/en-us)
+* RStudio Package Manager image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-package-manager), [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-package-manager)
 
 # Supported tags and respective Dockerfile links
 
@@ -14,9 +15,6 @@ Posit Package Manager, formerly RStudio Package Manager, is a repository managem
 R packages across your team, department, or entire organization. Get offline access to CRAN, automate CRAN syncs,
 share local packages, restrict package access, find packages across repositories, and more. Experience reliable and
 consistent package management, optimized for teams who use R.
-
-The following documentation helps an administrator install and configure Package Manager. It provides information for
-installing the product on different operating systems, upgrading, and configuring Package Manager.
 
 # Notice for support
 
@@ -40,7 +38,8 @@ installing the product on different operating systems, upgrading, and configurin
 
 # How to use this image
 
-To verify basic functionality as a first step:
+Below is a very simple example for running Package Manager locally in Docker using a product license key.
+
 ```bash
 # Replace with valid license
 export RSPM_LICENSE=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
@@ -51,6 +50,7 @@ docker run -it \
     -e RSPM_LICENSE=$RSPM_LICENSE \
     rstudio/rstudio-package-manager:ubuntu2204
 ```
+
 Open [http://localhost:4242](http://localhost:4242) to access RStudio Package Manager UI.
 
 ## Overview
@@ -61,7 +61,7 @@ This container includes:
 
 1. Two versions of R
 2. Two versions of Python
-3. RStudio Package Manager
+3. Posit Package Manager
 
 > NOTE: Package Manager is currently not very particular about R version. Changing the R version is rarely necessary.
 
@@ -70,7 +70,7 @@ This container includes:
 RStudio Package Manager is configured via the`/etc/rstudio-pm/rstudio-pm.gcfg` file. You should mount this file as
 a volume from the host machine. Changes will take effect when the container is restarted.
 
-Be sure the config file has the `[HTTP].Listen` field configured. See a complete example of that file at
+Be sure the config file has the `HTTP.Listen` field configured. See a complete example of that file at
 [`package-manager/rstudio-pm.gcfg`](./rstudio-pm.gcfg).
 
 ### Persistent Data
@@ -85,16 +85,103 @@ orchestration system to be available at `/var/lib/rstudio-pm`. Should you wish t
 DataDir = /mnt/rspm/data
 ```
 
-### Licensing
+### Product Licensing
 
-Using the RStudio Package Manager Docker image requires a valid license for Package Manager. You can set the license in three ways:
+Using the container requires a valid license for Posit Package Manager. You can set the license three different ways:
 
 1. Setting the `RSPM_LICENSE` environment variable to a valid license key inside the container
 2. Setting the `RSPM_LICENSE_SERVER` environment variable to a valid license server / port inside the container
-3. Mounting a `/etc/rstudio-pm/license.lic` single file that contains a valid license for RStudio Package Manager
+3. Mounting a license file at `/var/lib/rstudio-pm/*.lic` or a different path specified using `RSPM_LICENSE_FILE_PATH` that contains a valid license for RStudio Package Manager
 
 **NOTE:** the "offline activation process" is not supported by this image today. Offline installations will need
 to explore using a license server, license file, or custom image with manual intervention.
+
+#### Example usage with a license file
+
+The container will automatically look for a license file at `/var/lib/rstudio-pm/*.lic` and will attempt to use it
+for activation if present. This example uses a bind mount to provide the license file from the host machine.
+
+```bash
+docker run -it --privileged \
+    -p 4242:4242 \
+    --mount type=bind,ro,src=<path to license file>,dst=/var/lib/rstudio-pm/rstudio-pm.lic \
+    rstudio/rstudio-package-manager:ubuntu2204
+```
+
+Alternatively, the license file's path in the container can be provided using the `RSPM_LICENSE_FILE_PATH` environment 
+variable. If provided, the container will attempt to find and activate from the file at the given path.
+
+```bash
+docker run -it --privileged \
+    -p 4242:4242 \
+    -e RSPM_LICENSE_FILE_PATH=/opt/license.lic \
+    --mount type=bind,ro,src=<path to license file>,dst=/opt/license.lic \
+    rstudio/rstudio-package-manager:ubuntu2204
+```
+
+If the license file does not successfully activate, the container should fail to start under most circumstances. You can
+still verify the container's licensing status by running the `status` command against the `license-manager` binary.
+
+```bash
+$ docker exec -it <container name> /opt/rstudio-pm/bin/license-manager status
+TTY detected. Printing informational message about logging configuration. Logging configuration loaded from '/etc/rstudio/logging.conf'. Logging to '/var/log/rstudio/rstudio-server/license-manager.log'.
+RStudio License Manager 2024.04.2+764.pro1
+
+-- License file status --
+
+Status: Activated
+Product-Key: XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
+Has-Key: Yes
+Has-Trial: No
+Tier: Tier Name
+SKU-Year: 2024
+Enable-Launcher: 1
+Users: 0
+User-Activity-Days: 365
+Shiny-Users: 0
+Allow-APIs: 1
+Anonymous-Servers: 0
+Unrestricted-Servers: 0
+Licensee: Company Name
+License-File: /var/lib/rstudio-pm/rstudio-pm.lic
+Expiration: YYYY-MM-DD HH:mm:ss
+Days-Left: XXX
+License-Engine: 1.0.0.0
+License-Scope: System
+
+-- Local license status --
+
+Trial-Type: Verified
+Status: Expired
+Has-Key: No
+Has-Trial: Yes
+License-Scope: System
+License-Engine: 4.4.3.0
+
+-- Floating license status --
+
+License server not in use.
+```
+
+#### Example usage with a license key
+
+The container can also be activated using a license key by setting the `RSPM_LICENSE` environment variable. 
+
+```bash
+# Replace with valid license
+export RSPM_LICENSE=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
+
+# Run without persistent data and using an external configuration
+docker run -it --privileged \
+    -p 4242:4242 \
+    -e RSPM_LICENSE=$RSPM_LICENSE \
+    rstudio/rstudio-package-manager:ubuntu2204
+```
+
+If possible, license key activation should be avoided in production environments in favor of using a license file due to 
+the risk of leaking license activations when the container is not gracefully stopped. See the 
+[caveats of product licensing in containers](#caveats-of-product-licensing-in-containers) section below for more 
+details on license key issues.
 
 ### Environment variables
 
@@ -180,7 +267,7 @@ into issues with your license, please do not hesitate to [contact Posit support]
 While neither of these solutions will eliminate the problem, they should help mitigate it. We are still investigating a
 long-term solution.
 
-# Licensing
+# License
 
 The license associated with the RStudio Docker Products repository is located
 [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -12,9 +12,9 @@
 
 * [`jammy`, `ubuntu2204`, `jammy-2025.04.2`, `ubuntu2204-2025.04.2`](https://github.com/rstudio/rstudio-docker-products/blob/main/package-manager/Dockerfile.ubuntu2204)
 
-# What is RStudio Package Manager?
+# What is Posit Package Manager?
 
-Posit Package Manager, formerly RStudio Package Manager, is a repository management server to organize and centralize
+Posit Package Manager, formerly Posit Package Manager, is a repository management server to organize and centralize
 R packages across your team, department, or entire organization. Get offline access to CRAN, automate CRAN syncs,
 share local packages, restrict package access, find packages across repositories, and more. Experience reliable and
 consistent package management, optimized for teams who use R.
@@ -58,11 +58,11 @@ docker run -it \
     rstudio/rstudio-package-manager:ubuntu2204
 ```
 
-Open [http://localhost:4242](http://localhost:4242) to access RStudio Package Manager UI.
+Open [http://localhost:4242](http://localhost:4242) to access Posit Package Manager UI.
 
 ## Overview
 
-Note that running the RStudio Package Manager Docker image requires a valid RStudio Package Manager license.
+Note that running the Posit Package Manager Docker image requires a valid Posit Package Manager license.
 
 This container includes:
 
@@ -74,7 +74,7 @@ This container includes:
 
 ## Configuration
 
-RStudio Package Manager is configured via the`/etc/rstudio-pm/rstudio-pm.gcfg` file. You should mount this file as
+Posit Package Manager is configured via the`/etc/rstudio-pm/rstudio-pm.gcfg` file. You should mount this file as
 a volume from the host machine. Changes will take effect when the container is restarted.
 
 Be sure the config file has the `HTTP.Listen` field configured. See a complete example of that file at
@@ -99,7 +99,7 @@ Using the container requires a valid license for Posit Package Manager. You can 
 1. Setting the `RSPM_LICENSE` environment variable to a valid license key inside the container
 2. Setting the `RSPM_LICENSE_SERVER` environment variable to a valid license server / port inside the container
 3. Mounting a license file at `/var/lib/rstudio-pm/*.lic` or a different path specified using `RSPM_LICENSE_FILE_PATH`
-   that contains a valid license for RStudio Package Manager
+   that contains a valid license for Posit Package Manager
 
 **NOTE:** the "offline activation process" is not supported by this image today. Offline installations will need
 to explore using a license server, license file, or custom image with manual intervention.
@@ -195,14 +195,14 @@ details on license key issues.
 
 | Variable | Description | Default |
 |-----|---|---|
-| `RSPM_LICENSE` | License key for RStudio Package Manager, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX` | None |
+| `RSPM_LICENSE` | License key for Posit Package Manager, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX` | None |
 | `RSPM_LICENSE_SERVER` | Floating license server, format should be: `my.url.com:port` | None |
 
 ### Ports
 
 | Variable | Description |
 |----------|---|
-| `4242`   | Default HTTP Port for RStudio Package Manager |
+| `4242`   | Default HTTP Port for Posit Package Manager |
 
 ### Example usage
 
@@ -226,7 +226,7 @@ docker run -it \
     rstudio/rstudio-package-manager:ubuntu2204
 ```
 
-Open [http://localhost:4242](http://localhost:4242) to access RStudio Package Manager UI.
+Open [http://localhost:4242](http://localhost:4242) to access Posit Package Manager UI.
 
 To create repositories you need to access the container directly and execute some commands.
 To do this find the container ID for RSPM (using `docker ps`) and run:
@@ -235,8 +235,8 @@ To do this find the container ID for RSPM (using `docker ps`) and run:
 docker exec -it {container-id} /bin/bash
 ```
 
-Then please refer to the [RSPM guide](https://docs.rstudio.com/rspm/admin/) on how
-to [create and manage](https://docs.rstudio.com/rspm/admin/getting-started/configuration/) your repositories.
+Then please refer to the [Package Manager documentation](https://docs.posit.co/rspm/admin/) on how
+to [create and manage](https://docs.posit.co/rspm/admin/getting-started/configuration.html) your repositories.
 
 ## Caveats of product licensing in containers
 
@@ -277,7 +277,7 @@ long-term solution.
 
 # License
 
-The license associated with the RStudio Docker Products repository is located
+The license associated with the Posit Docker Products repository is located
 [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
 
 As is the case with all container images, the images themselves also contain other software which may be under other

--- a/package-manager/startup.sh
+++ b/package-manager/startup.sh
@@ -36,6 +36,8 @@ if ! [ -z "$RSPM_LICENSE" ]; then
     /opt/rstudio-pm/bin/license-manager activate $RSPM_LICENSE --userspace
 elif ! [ -z "$RSPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server $RSPM_LICENSE_SERVER --userspace
+elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
 elif test -f "$RSPM_LICENSE_FILE_PATH"; then
     /opt/rstudio-pm/bin/license-manager activate-file $RSPM_LICENSE_FILE_PATH --userspace
 fi
@@ -43,6 +45,7 @@ fi
 # ensure these cannot be inherited by child processes
 unset RSPM_LICENSE
 unset RSPM_LICENSE_SERVER
+unset RSPM_LICENSE_FILE_PATH
 
 # Start RStudio Package Manager
 /opt/rstudio-pm/bin/rstudio-pm --config /etc/rstudio-pm/rstudio-pm.gcfg

--- a/package-manager/startup.sh
+++ b/package-manager/startup.sh
@@ -36,11 +36,15 @@ if ! [ -z "$RSPM_LICENSE" ]; then
     /opt/rstudio-pm/bin/license-manager activate $RSPM_LICENSE --userspace
 elif ! [ -z "$RSPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server $RSPM_LICENSE_SERVER --userspace
-elif test -f "$RSPM_LICENSE_FILE_PATH"; then
-    rm -f /var/lib/rstudio-pm/*.lic || true
-    /opt/rstudio-pm/bin/license-manager activate-file $RSPM_LICENSE_FILE_PATH --userspace
+elif test -f "${RSPM_LICENSE_FILE_PATH}"; then
+    mkdir -p /home/rstudio-pm/.rstudio-pm
+    cp "${RSPM_LICENSE_FILE_PATH}" /home/rstudio-pm/.rstudio-pm/license.lic
+    chown rstudio-pm /home/rstudio-pm/.rstudio-pm/license.lic
+    chmod 0600 /home/rstudio-pm/.rstudio-pm/license.lic
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
+elif ls /home/rstudio-pm/.rstudio-pm/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in /home/rstudio-pm/.rstudio-pm/*.lic."
 fi
 
 # ensure these cannot be inherited by child processes

--- a/package-manager/startup.sh
+++ b/package-manager/startup.sh
@@ -36,10 +36,11 @@ if ! [ -z "$RSPM_LICENSE" ]; then
     /opt/rstudio-pm/bin/license-manager activate $RSPM_LICENSE --userspace
 elif ! [ -z "$RSPM_LICENSE_SERVER" ]; then
     /opt/rstudio-pm/bin/license-manager license-server $RSPM_LICENSE_SERVER --userspace
+elif test -f "$RSPM_LICENSE_FILE_PATH"; then
+    rm -f /var/lib/rstudio-pm/*.lic || true
+    /opt/rstudio-pm/bin/license-manager activate-file $RSPM_LICENSE_FILE_PATH --userspace
 elif ls /var/lib/rstudio-pm/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-pm/*.lic."
-elif test -f "$RSPM_LICENSE_FILE_PATH"; then
-    /opt/rstudio-pm/bin/license-manager activate-file $RSPM_LICENSE_FILE_PATH --userspace
 fi
 
 # ensure these cannot be inherited by child processes

--- a/r-session-complete/NEWS.md
+++ b/r-session-complete/NEWS.md
@@ -1,3 +1,7 @@
+# 2025-07-03
+
+- Update README.md links.
+
 # 2025.03.11
 
 - Quarto TinyTeX installation path has been updated from `/root/.TinyTeX` to `/opt/.TinyTeX` to fix potential permission 

--- a/r-session-complete/README.md
+++ b/r-session-complete/README.md
@@ -1,9 +1,14 @@
 # Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
-* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues)
-* RStudio Workbench image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-workbench)
-* RStudio r-session-complete image: [Docker Hub](https://hub.docker.com/r/rstudio/r-session-complete)
+* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 
+  [the Posit Package Manager Documentation](https://docs.posit.co/ide/), 
+  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/posit-workbench/69), 
+  or [Posit Support](https://support.posit.co/hc/en-us)
+* Posit Workbench image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-workbench), 
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-workbench)
+* Posit r-session-complete image: [Docker Hub](https://hub.docker.com/r/rstudio/r-session-complete), 
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/r-session-complete)
 
 # Supported tags and respective Dockerfile links
 
@@ -11,7 +16,7 @@
 
 # What are the r-session-complete images?
 
-Images for R and Python sessions and jobs to be used RStudio Workbench, Launcher, and Kubernetes.
+Images for R and Python sessions and jobs to be used Posit Workbench, Launcher, and Kubernetes.
 
 # Notice for support
 
@@ -25,27 +30,31 @@ Images for R and Python sessions and jobs to be used RStudio Workbench, Launcher
    changes. We
    provide [instructions for how to build and use](#how-to-use-these-docker-images)
    for these cases.
-1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version 
+   was released/updated. They should be reviewed and updated before production use. If your organization has a specific 
+   set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the 
+   [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal 
+   security standards.
 
 # How to use these images
 
 The Docker images built from these Dockerfiles are intended to be used for R and
-Jupyter sessions and jobs with RStudio Workbench (RSW), Launcher, and
+Jupyter sessions and jobs with Posit Workbench (also referred to as PWB or RSW), Launcher, and
 Kubernetes.
 
-Note: These Docker images are not equipped or intended to be used to run RStudio
+Note: These Docker images are not equipped or intended to be used to run Posit
 Workbench within a Docker container. Visit the
 [rstudio/rstudio-worbench Docker Hub page](https://hub.docker.com/r/rstudio/rstudio-workbench)
 for images built for that purpose.
 
-For more information about RStudio Workbench and Launcher, refer to the
-[Launcher Overview](https://solutions.rstudio.com/launcher/overview/) on the
-RStudio Solutions website.
+For more information about Posit Workbench and Launcher, refer to the
+[Launcher Overview](https://docs.posit.co/ide/server-pro/admin/job_launcher/job_launcher.html) in the
+Workbench Documentation.
 
-For more information about how to use these images with RStudio Workbench and
-Launcher, refer to the RStudio support article on [Using Docker images with
-RStudio Workbench, Launcher, and
-Kubernetes](https://support.rstudio.com/hc/en-us/articles/360019253393-Using-Docker-images-with-RStudio-Server-Pro-Launcher-and-Kubernetes).
+For more information about how to use these images with Posit Workbench and
+Launcher, refer to the Posit support article on [Using Docker images with
+Posit Workbench, Launcher, and
+Kubernetes](https://support.posit.co/hc/en-us/articles/360019253393-Using-Docker-images-with-Posit-Workbench-Launcher-and-Kubernetes).
 
 We provide simple ways to extend and build the Dockerfiles. After you have cloned the repo, you can create your own
 containers fairly simply with the provided Justfile.
@@ -56,19 +65,19 @@ Built images are available from the
 [rstudio/r-session-complete](https://hub.docker.com/r/rstudio/r-session-complete)
 repository on Docker Hub.
 
-These images include the following layers:
+These images include the following components:
 
 * Base OS
 * RSW session components
-* System packages required for R, R packages, and RStudio Professional Drivers
+* System packages required for R, R packages, and Posit Professional Drivers
 * One version of R
 * One version of Python
-* Jupyter Notebooks, JupyterLab, and RSW/RSC notebook extensions
-* RStudio Professional Drivers
+* Jupyter Notebooks, JupyterLab, and PWB/PCT notebook extensions
+* Posit Professional Drivers
 
-# Licensing
+# License
 
-The license associated with the RStudio Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
+The license associated with the Posit Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
 
 As is the case with all container images, the images themselves also contain other software which may be under other
 licenses (i.e. bash, linux, system libraries, etc., along with any other direct or indirect dependencies of the primary

--- a/workbench-for-google-cloud-workstations/README.md
+++ b/workbench-for-google-cloud-workstations/README.md
@@ -1,4 +1,4 @@
-_# Quick reference
+# Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
 * Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues)
@@ -42,7 +42,7 @@ https://www.rstudio.com/products/workbench/.
 # How to use this image
 
 This image is designed for exclusive use with [Google Cloud Workstations](https://cloud.google.com/workstations). For
-the generalized version of the Workbench image, go [here](../workbench).
+the generalized version of the Workbench image, go [here](https://hub.docker.com/r/rstudio/rstudio-workbench).
 
 Using Google Cloud Workstations requires a Google Cloud Platform account. Click 
 [here](https://console.cloud.google.com/workstations/overview) to navigate to the Cloud Workstations console. Posit
@@ -62,24 +62,25 @@ This container includes:
 
 1. Two versions of R
 2. Two versions of Python
-3. RStudio Workbench
+3. Quarto
+4. Posit Workbench
 
-### Licensing
+### Product Licensing
 
 The RStudio Workbench Docker image requires a valid license, which can be set using the `RSW_LICENSE` environment 
 variable to a valid license key inside the container.
 
 ### Environment variables
 
-| Variable | Description | Default   |
-|-----|---|-----------|
-| `RSW_LICENSE` | License key for RStudio Workbench, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX` | None      |
-| `RSW_LAUNCHER` | Whether or not to use launcher locally / start the launcher process | true      |
-| `RSW_LAUNCHER_TIMEOUT` | The timeout, in seconds, to wait for launcher to start listening on the expected port before failing startup | 10        |
+| Variable               | Description                                                                                                  | Default |
+|------------------------|--------------------------------------------------------------------------------------------------------------|---------|
+| `RSW_LICENSE`          | License key for Posit Workbench, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`                      | None    |
+| `RSW_LAUNCHER`         | Whether or not to use launcher locally / start the launcher process                                          | true    |
+| `RSW_LAUNCHER_TIMEOUT` | The timeout, in seconds, to wait for launcher to start listening on the expected port before failing startup | 10      |
 
-# Licensing
+# License
 
-The license associated with the RStudio Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
+The license associated with the Posit Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
 
 As is the case with all container images, the images themselves also contain other software which may be under other
 licenses (i.e. bash, linux, system libraries, etc., along with any other direct or indirect dependencies of the primary

--- a/workbench-for-google-cloud-workstations/startup.sh
+++ b/workbench-for-google-cloud-workstations/startup.sh
@@ -33,20 +33,25 @@ RSP_LICENSE=${RSP_LICENSE:-${RSW_LICENSE}}
 RSP_LICENSE_SERVER=${RSP_LICENSE_SERVER:-${RSW_LICENSE_SERVER}}
 
 # Activate License
-RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}
+RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-${RSP_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}}
 if [ -n "$RSP_LICENSE" ]; then
     ${LICENSE_MANAGER_PATH}/license-manager activate $RSP_LICENSE || true
 elif [ -n "$RSP_LICENSE_SERVER" ]; then
     ${LICENSE_MANAGER_PATH}/license-manager license-server $RSP_LICENSE_SERVER || true
 elif test -f "$RSW_LICENSE_FILE_PATH"; then
+    rm -f /var/lib/rstudio-server/*.lic
     ${LICENSE_MANAGER_PATH}/license-manager activate-file $RSW_LICENSE_FILE_PATH || true
+elif ls /var/lib/rstudio-server/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in /var/lib/rstudio-server/*.lic."
 fi
 
 # ensure these cannot be inherited by child processes
 unset RSP_LICENSE
 unset RSP_LICENSE_SERVER
+unset RSP_LICENSE_FILE_PATH
 unset RSW_LICENSE
 unset RSW_LICENSE_SERVER
+unset RSW_LICENSE_FILE_PATH
 
 # Start Launcher
 if [ "$RSW_LAUNCHER" == "true" ]; then

--- a/workbench-for-google-cloud-workstations/startup.sh
+++ b/workbench-for-google-cloud-workstations/startup.sh
@@ -38,9 +38,11 @@ if [ -n "$RSP_LICENSE" ]; then
     ${LICENSE_MANAGER_PATH}/license-manager activate $RSP_LICENSE || true
 elif [ -n "$RSP_LICENSE_SERVER" ]; then
     ${LICENSE_MANAGER_PATH}/license-manager license-server $RSP_LICENSE_SERVER || true
-elif test -f "$RSW_LICENSE_FILE_PATH"; then
+elif test -f "${RSW_LICENSE_FILE_PATH}"; then
     rm -f /var/lib/rstudio-server/*.lic
-    ${LICENSE_MANAGER_PATH}/license-manager activate-file $RSW_LICENSE_FILE_PATH || true
+    cp "${RSW_LICENSE_FILE_PATH}" /var/lib/rstudio-server/license.lic
+    chown rstudio-server /var/lib/rstudio-server/license.lic
+    chmod 600 /var/lib/rstudio-server/license.lic
 elif ls /var/lib/rstudio-server/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-server/*.lic."
 fi

--- a/workbench-for-microsoft-azure-ml/NEWS.md
+++ b/workbench-for-microsoft-azure-ml/NEWS.md
@@ -1,4 +1,11 @@
-# 2025.03.11
+# 2025-07-03
+
+- Update documentation with additional license file usage instructions.
+- Replace usage of `license-manager activate-file` with file copies for installing license files per Workbench admin 
+  guide.
+- Add startup message for when a license file is found in `/var/lib/rstudio-server/*.lic`.
+
+# 2025-03-11
 
 - Quarto TinyTeX installation path has been updated from `/root/.TinyTeX` to `/opt/.TinyTeX` to fix potential permission 
   issues when called from a non-root user. As a result, Quarto will no longer recognize TinyTeX as a managed 

--- a/workbench-for-microsoft-azure-ml/startup.sh
+++ b/workbench-for-microsoft-azure-ml/startup.sh
@@ -30,13 +30,16 @@ RSP_LICENSE=${RSP_LICENSE:-${RSW_LICENSE}}
 RSP_LICENSE_SERVER=${RSP_LICENSE_SERVER:-${RSW_LICENSE_SERVER}}
 
 # Activate License
-RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}
+RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-${RSP_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}}
 if [ -n "$RSP_LICENSE" ]; then
     ${LICENSE_MANAGER_PATH}/license-manager activate $RSP_LICENSE || true
 elif [ -n "$RSP_LICENSE_SERVER" ]; then
     ${LICENSE_MANAGER_PATH}/license-manager license-server $RSP_LICENSE_SERVER || true
 elif test -f "$RSW_LICENSE_FILE_PATH"; then
+    rm -f /var/lib/rstudio-server/*.lic
     ${LICENSE_MANAGER_PATH}/license-manager activate-file $RSW_LICENSE_FILE_PATH || true
+elif ls /var/lib/rstudio-server/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in /var/lib/rstudio-server/*.lic."
 fi
 
 # ensure these cannot be inherited by child processes
@@ -44,6 +47,7 @@ unset RSP_LICENSE
 unset RSP_LICENSE_SERVER
 unset RSW_LICENSE
 unset RSW_LICENSE_SERVER
+unset RSW_LICENSE_FILE_PATH
 
 # Create one user
 if [ $(getent passwd $PUID) ] ; then

--- a/workbench-for-microsoft-azure-ml/startup.sh
+++ b/workbench-for-microsoft-azure-ml/startup.sh
@@ -35,9 +35,11 @@ if [ -n "$RSP_LICENSE" ]; then
     ${LICENSE_MANAGER_PATH}/license-manager activate $RSP_LICENSE || true
 elif [ -n "$RSP_LICENSE_SERVER" ]; then
     ${LICENSE_MANAGER_PATH}/license-manager license-server $RSP_LICENSE_SERVER || true
-elif test -f "$RSW_LICENSE_FILE_PATH"; then
+elif test -f "${RSW_LICENSE_FILE_PATH}"; then
     rm -f /var/lib/rstudio-server/*.lic
-    ${LICENSE_MANAGER_PATH}/license-manager activate-file $RSW_LICENSE_FILE_PATH || true
+    cp "${RSW_LICENSE_FILE_PATH}" /var/lib/rstudio-server/license.lic
+    chown rstudio-server /var/lib/rstudio-server/license.lic
+    chmod 600 /var/lib/rstudio-server/license.lic
 elif ls /var/lib/rstudio-server/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-server/*.lic."
 fi

--- a/workbench-session-init/NEWS.md
+++ b/workbench-session-init/NEWS.md
@@ -1,3 +1,7 @@
+# 2025-07-03
+
+- Update README.md with quick reference.
+
 # 2024.11.0
 
 - Add NEWS.md

--- a/workbench-session-init/README.md
+++ b/workbench-session-init/README.md
@@ -1,50 +1,29 @@
-# Posit Workbench Session Init Container
-
-This directory contains a Dockerfile and script that will create an init container to copy session runtime components from a release package into a target mount directory. This init container can be used to pull the session runtime components into another base sesssion image, which can then be used to run Workbench sessions.
-
-## Quick reference
+# Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
-* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues)
-* Posit Workbench image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-workbench)
-* Posit Workbench session image: [Docker Hub](https://hub.docker.com/r/rstudio/workbench-session)
-* Posit Workbench session init image: [Docker Hub](https://hub.docker.com/r/rstudio/workbench-session-init)
+* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 
+  [the Posit Workbench Documentation](https://docs.posit.co/ide/), 
+  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/posit-workbench/69), 
+  or [Posit Support](https://support.posit.co/hc/en-us)
+* Posit Workbench image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-workbench), 
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-workbench)
+* Posit Workbench session image: [Docker Hub](https://hub.docker.com/r/rstudio/workbench-session),
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/workbench-session)
+* Posit Workbench session init image: [Docker Hub](https://hub.docker.com/r/rstudio/workbench-session-init),
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/workbench-session-init)
+
+# Posit Workbench Session Init Container
+
+This init container can be used to pull the session runtime components into another base session image, which can then 
+be used to run Workbench sessions. This image is intended to be used in conjunction with the 
+[Posit Workbench Session](https://hub.docker.com/r/rstudio/workbench-session) and 
+[Posit Workbench](https://hub.docker.com/r/rstudio/rstudio-workbench) images.
 
 ## Supported tags and respective Dockerfile links
 
 * [`jammy-daily`, `ubuntu2204-daily`, `jammy-2025.05.1`, `ubuntu2204-2025.05.1`](https://github.com/rstudio/rstudio-docker-products/blob/main/workbench-session-init/Dockerfile.2204)
 
-## Building
-
-Just will build an image using a default Connect distribution.
-
-```console
-just build
-```
-
-Daily builds are also supported. To build the daily image, run:
-
-```console
-just preview-bake workbench-session-init-daily
-```
-
-## Testing
-
-You can observe what gets copied by the container:
-
-```console
-mkdir init
-docker run --rm -v $(pwd)/init:/mnt/init rstudio/workbench-session-init:jammy-2025.05.1
-# The init directory has been populated with the Workbench session runtime components.
-```
-
-You can also test using GOSS:
-
-```console
-just test workbench-session-init
-```
-
-## Licensing
+## License
 
 The license associated with the RStudio Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
 

--- a/workbench-session/NEWS.md
+++ b/workbench-session/NEWS.md
@@ -1,3 +1,7 @@
+# 2025-07-03
+
+- Update README.md links.
+
 # 2024-11-15
 
 - Add NEWS.md

--- a/workbench-session/README.md
+++ b/workbench-session/README.md
@@ -1,16 +1,22 @@
 # Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
-* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues)
-* Posit Workbench image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-workbench)
-* Posit Workbench session image: [Docker Hub](https://hub.docker.com/r/rstudio/workbench-session)
-* Posit Workbench session init image: [Docker Hub](https://hub.docker.com/r/rstudio/workbench-session-init)
+* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 
+  [the Posit Workbench Documentation](https://docs.posit.co/ide/), 
+  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/posit-workbench/69), 
+  or [Posit Support](https://support.posit.co/hc/en-us)
+* Posit Workbench image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-workbench), 
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-workbench)
+* Posit Workbench session image: [Docker Hub](https://hub.docker.com/r/rstudio/workbench-session),
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/workbench-session)
+* Posit Workbench session init image: [Docker Hub](https://hub.docker.com/r/rstudio/workbench-session-init),
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/workbench-session-init)
 
 # Supported tags and respective Dockerfile links
 
 * [`ubuntu2204-r4.4.1_4.3.3-py3.12.6_3.11.10`, `ubuntu2204-r4.4.1_4.3.3-py3.11.10_3.10.15`, `ubuntu2204-r4.4.0_4.3.3-py3.12.1_3.11.7`](https://github.com/rstudio/rstudio-docker-products/blob/main/workbench-session/Dockerfile.ubuntu2204)
 
-# What are the r-session-complete images?
+# What are the Workbench Session images?
 
 Images for R and Python sessions and jobs to be used RStudio Workbench, Launcher, and Kubernetes.
 
@@ -26,7 +32,11 @@ Images for R and Python sessions and jobs to be used RStudio Workbench, Launcher
    changes. We
    provide [instructions for how to build and use](#how-to-use-these-docker-images)
    for these cases.
-1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version 
+   was released/updated. They should be reviewed and updated before production use. If your organization has a specific 
+   set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the 
+   [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal 
+   security standards.
 
 # How to use these images
 
@@ -39,22 +49,25 @@ Workbench within a Docker container. Visit the
 [rstudio/rstudio-worbench Docker Hub page](https://hub.docker.com/r/rstudio/rstudio-workbench)
 for images built for that purpose.
 
-Note: These images do not include the Posit Workbench Session Components. To use these images with Posit Workbench, the [session init container](https://hub.docker.com/r/rstudio/workbench-session-init) must be enabled within the Posit Workbench configuration. For more information, refer to the [Posit Workbench documentation](https://docs.rstudio.com/ide/server-pro/launcher/).
+Note: These images do not include the Posit Workbench Session Components. To use these images with Posit Workbench, the 
+[session init container](https://hub.docker.com/r/rstudio/workbench-session-init) must be enabled within the Posit 
+Workbench configuration. For more information, refer to the 
+[Posit Workbench documentation](https://docs.posit.co/ide/server-pro/admin/job_launcher/using_docker_images.html).
 
 For more information about Posit Workbench and Launcher, refer to the
-[Launcher Overview](https://solutions.rstudio.com/launcher/overview/) on the
-RStudio Solutions website.
+[Launcher Overview](https://docs.posit.co/ide/server-pro/admin/job_launcher/job_launcher.html) in the
+Posit Workbench documentation.
 
-For more information about how to use these images with RStudio Workbench and
-Launcher, refer to the RStudio support article on [Using Docker images with
-RStudio Workbench, Launcher, and Kubernetes](https://support.rstudio.com/hc/en-us/articles/360019253393-Using-Docker-images-with-RStudio-Server-Pro-Launcher-and-Kubernetes).
+For more information about how to use these images with Posit Workbench and
+Launcher, refer to the support article on [Using Docker images with
+Posit Workbench, Launcher, and Kubernetes](https://support.posit.co/hc/en-us/articles/360019253393-Using-Docker-images-with-Posit-Workbench-Launcher-and-Kubernetes).
 
-We provide simple ways to extend and build the Dockerfiles. After you have cloned the repo, you can create your own containers fairly simply with the provided Justfile.
+We provide simple ways to extend and build the Dockerfiles. After you have cloned the repo, you can create your own 
+containers fairly simply with the provided Justfile in the repository.
 
 ## Overview
 
-Built images are available from the
-[rstudio/workbench-session](https://hub.docker.com/r/rstudio/workbench-session)
+Built images are available from the [rstudio/workbench-session](https://hub.docker.com/r/rstudio/workbench-session)
 repository on Docker Hub.
 
 These images include the following layers:
@@ -66,9 +79,9 @@ These images include the following layers:
 * Jupyter Notebooks, JupyterLab, and RSW/RSC notebook extensions
 * RStudio Professional Drivers
 
-# Licensing
+# License
 
-The license associated with the RStudio Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
+The license associated with the Posit Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
 
 As is the case with all container images, the images themselves also contain other software which may be under other
 licenses (i.e. bash, linux, system libraries, etc., along with any other direct or indirect dependencies of the primary

--- a/workbench/NEWS.md
+++ b/workbench/NEWS.md
@@ -1,4 +1,11 @@
-# 2025.03.11
+# 2025-07-03
+
+- Update documentation with additional license file usage instructions.
+- Replace usage of `license-manager activate-file` with file copies for installing license files per Workbench admin 
+  guide.
+- Add startup message for when a license file is found in `/var/lib/rstudio-server/*.lic`.
+
+# 2025-03-11
 
 - Quarto TinyTeX installation path has been updated from `/root/.TinyTeX` to `/opt/.TinyTeX` to fix potential permission 
   issues when called from a non-root user. As a result, Quarto will no longer recognize TinyTeX as a managed 

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -1,15 +1,20 @@
 # Quick reference
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
-* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues)
-* RStudio Workbench image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-workbench)
-* RStudio r-session-complete image: [Docker Hub](https://hub.docker.com/r/rstudio/r-session-complete)
+* Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 
+  [the Posit Workbench Documentation](https://docs.posit.co/ide/), 
+  [the Posit Community Forum](https://forum.posit.co/c/posit-professional-hosted/posit-workbench/69), 
+  or [Posit Support](https://support.posit.co/hc/en-us)
+* Posit Workbench image: [Docker Hub](https://hub.docker.com/r/rstudio/rstudio-workbench), 
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/rstudio-workbench)
+* Posit r-session-complete image: [Docker Hub](https://hub.docker.com/r/rstudio/r-session-complete), 
+  [GHCR](https://github.com/rstudio/rstudio-docker-products/pkgs/container/r-session-complete)
 
 # Supported tags and respective Dockerfile links
 
 * [`jammy`, `ubuntu2204`, `jammy-2025.05.1`, `ubuntu2204-2025.05.1`](https://github.com/rstudio/rstudio-docker-products/blob/main/workbench/Dockerfile.ubuntu2204)
 
-# What is RStudio Workbench?
+# What is Posit Workbench?
 
 Posit Workbench, formerly RStudio Workbench, is the preferred data analysis and integrated development experience for
 professional R users and data science teams who use R and Python. Posit Workbench enables the collaboration,
@@ -21,7 +26,7 @@ Some of the functionality that Workbench provides is:
 * The ability to develop in Workbench and Jupyter
 * Load balancing
 * Tutorial API
-* Data connectivity and Posit Professional Drivers (formerly RStudio Professional Drivers)
+* Data connectivity and Posit Professional Drivers
 * Collaboration and project sharing
 * Scale with Kubernetes and SLURM
 * Authentication, access, & security
@@ -30,7 +35,8 @@ Some of the functionality that Workbench provides is:
 * Auditing and monitoring
 * Advanced R and Python session management
 
-For more information on running RStudio Workbench in your organization please visit https://www.rstudio.com/products/workbench/.
+For more information on running Posit Workbench in your organization please visit 
+https://posit.co/products/enterprise/workbench/.
 
 # Notice for support
 
@@ -44,12 +50,16 @@ For more information on running RStudio Workbench in your organization please vi
    changes. We
    provide [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) for
    these cases.
-1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version was released/updated. They should be reviewed and updated before production use. If your organization has a specific set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal security standards.
+1. **Security Note:** These images are provided AS IS based on the build environment at the time their product version 
+   was released/updated. They should be reviewed and updated before production use. If your organization has a specific 
+   set of security requirements related to CVE/Vulnerability severity levels, you should plan to use the 
+   [instructions for building](https://github.com/rstudio/rstudio-docker-products#instructions-for-building) to clone this repository, and rebuild these images to your specific internal 
+   security standards.
 
 
 # How to use this image
 
-To verify basic functionality as a first step:
+Below is a very simple example for running Workbench locally in Docker using a product license key.
 
 ```
 # Replace with valid license
@@ -59,29 +69,31 @@ export RSW_LICENSE=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
 docker run -it \
     -p 8787:8787 \
     -e RSW_LICENSE=$RSW_LICENSE \
-    rstudio/rstudio-workbench:ubuntu1804
+    rstudio/rstudio-workbench:ubuntu2204
 ```
 
 
-Open [http://localhost:8787](http://localhost:8787) to access RStudio Workbench. The default username and password are
+Open [http://localhost:8787](http://localhost:8787) to access Posit Workbench. The default username and password are
 `rstudio`.
 
 ## Overview
 
-Note that running the RStudio Workbench Docker image requires a valid RStudio Workbench license.
+Note that running the Posit Workbench Docker image requires a valid Posit Workbench license.
 
 This container includes:
 
 1. Two versions of R
 2. Two versions of Python
-3. RStudio Workbench
+3. Quarto
+4. Posit Professional Drivers
+5. Posit Workbench
 
 ## Configuration
 
-RStudio Workbench is configured via config files in the `/etc/rstudio` directory. Mount this directory as
+Posit Workbench is configured via config files in the `/etc/rstudio` directory. Mount this directory as
 a volume from the host machine. Changes will take effect when the container is restarted.
 
-You can review possible RStudio Workbench configuration [in the documentation](https://docs.rstudio.com/ide/workbench/).
+You can review possible Posit Workbench configuration [in the documentation](https://docs.posit.co/ide/).
 
 See a complete example of server configuration at `workbench/conf`.
 
@@ -90,16 +102,104 @@ See a complete example of server configuration at `workbench/conf`.
 In order to persist user files between container restarts please mount the `/home` directory from a persistent volume on the host
 machine or your docker orchestration system.
 
-### Licensing
+### Product Licensing
 
-The RStudio Workbench Docker image requires a valid license, which can be set in three ways:
+The Posit Workbench Docker image requires a valid license, which can be set in three ways:
 
 1. Setting the `RSW_LICENSE` environment variable to a valid license key inside the container
 2. Setting the `RSW_LICENSE_SERVER` environment variable to a valid license server / port inside the container
-3. Mounting a `/etc/rstudio-server/license.lic` single file that contains a valid license for RStudio Workbench
+3. Mounting a license file at `/var/lib/rstudio-server/*.lic` or a different path specified using 
+   `RSW_LICENSE_FILE_PATH` that contains a valid license for Posit Workbench
 
-**NOTE:** the "offline activation process" is not supported by this image today. Offline installations will need
-to explore using a license server, license file, or custom image with manual intervention.
+**NOTE:** Offline installations will need to use a floating license server, license file, or custom image with manual 
+intervention to successfully activate the instance.
+
+#### Example usage with a license file
+
+The container will automatically look for a license file at `/var/lib/rstudio-server/*.lic` and will attempt to use it
+for activation if present. This example uses a bind mount to provide the license file from the host machine.
+
+```bash
+docker run -it --privileged \
+    -p 8787:8787 \
+    --mount type=bind,ro,src=<path to license file>,dst=/var/lib/rstudio-server/rstudio-server.lic \
+    rstudio/rstudio-workbench:ubuntu2204
+```
+
+Alternatively, the license file's path in the container can be provided using the `RSW_LICENSE_FILE_PATH` environment 
+variable. If provided, the container will attempt to find and activate from the file at the given path.
+
+```bash
+docker run -it --privileged \
+    -p 8787:8787 \
+    -e RSW_LICENSE_FILE_PATH=/opt/license.lic \
+    --mount type=bind,ro,src=<path to license file>,dst=/opt/license.lic \
+    rstudio/rstudio-workbench:ubuntu2204
+```
+
+If the license file does not successfully activate, the container should fail to start under most circumstances. You can
+still verify the container's licensing status by running the `status` command against the `license-manager` binary.
+
+```bash
+$ docker exec -it <container name> /lib/rstudio-server/bin/license-manager status
+TTY detected. Printing informational message about logging configuration. Logging configuration loaded from '/etc/rstudio/logging.conf'. Logging to '/var/log/rstudio/rstudio-server/license-manager.log'.
+RStudio License Manager 2024.04.2+764.pro1
+
+-- License file status --
+
+Status: Activated
+Product-Key: XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
+Has-Key: Yes
+Has-Trial: No
+Tier: Tier Name
+SKU-Year: 2024
+Enable-Launcher: 1
+Users: 0
+User-Activity-Days: 365
+Shiny-Users: 0
+Allow-APIs: 1
+Anonymous-Servers: 0
+Unrestricted-Servers: 0
+Licensee: Company Name
+License-File: /var/lib/rstudio-server/rstudio-server.lic
+Expiration: YYYY-MM-DD HH:mm:ss
+Days-Left: XXX
+License-Engine: 1.0.0.0
+License-Scope: System
+
+-- Local license status --
+
+Trial-Type: Verified
+Status: Expired
+Has-Key: No
+Has-Trial: Yes
+License-Scope: System
+License-Engine: 4.4.3.0
+
+-- Floating license status --
+
+License server not in use.
+```
+
+#### Example usage with a license key
+
+The container can also be activated using a license key by setting the `RSW_LICENSE` environment variable. 
+
+```bash
+# Replace with valid license
+export RSW_LICENSE=XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX
+
+# Run without persistent data and using an external configuration
+docker run -it --privileged \
+    -p 4242:4242 \
+    -e RSW_LICENSE=$RSW_LICENSE \
+    rstudio/rstudio-workbench:ubuntu2204
+```
+
+If possible, license key activation should be avoided in production environments in favor of using a license file due to 
+the risk of leaking license activations when the container is not gracefully stopped. See the 
+[caveats of product licensing in containers](#caveats-of-product-licensing-in-containers) section below for more 
+details on license key issues.
 
 ### User Provisioning
 
@@ -138,33 +238,33 @@ docker run -it \
     -v $PWD/server-pro/conf/:/etc/rstudio \
     -v $PWD/sssd.conf:/etc/sssd/conf.d/sssd.conf \
     -e RSW_LICENSE=$RSW_LICENSE \
-    rstudio/rstudio-workbench:ubuntu1804
+    rstudio/rstudio-workbench:ubuntu2204
 ```
 
 It is worth noting that you may also need to modify the PAM configuration files
 in the container, if you are using PAM for custom authentication or session
-behavior. See the [RStudio Workbench
-guide](https://docs.rstudio.com/ide/server-pro/authenticating-users.html) for
+behavior. See the [Posit Workbench guide](
+https://docs.posit.co/ide/server-pro/admin/authenticating_users/authenticating_users.html) for
 more information.
 
 ### Environment variables
 
-| Variable | Description | Default   |
-|-----|---|-----------|
-| `RSW_TESTUSER` | Test user to be created in the container, turn off with an empty value | `rstudio` |
-| `RSW_TESTUSER_PASSWD` | Test user password | `rstudio` |
-| `RSW_TESTUSER_UID` | Test user UID | `10000`   |
-| `RSW_LICENSE` | License key for RStudio Workbench, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX` | None      |
-| `RSW_LICENSE_SERVER` | Floating license server, format should be: `my.url.com:port` | None      |
-| `RSW_LAUNCHER` | Whether or not to use launcher locally / start the launcher process | true      |
+| Variable               | Description                                                                                                  | Default   |
+|------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
+| `RSW_TESTUSER`         | Test user to be created in the container, turn off with an empty value                                       | `rstudio` |
+| `RSW_TESTUSER_PASSWD`  | Test user password                                                                                           | `rstudio` |
+| `RSW_TESTUSER_UID`     | Test user UID                                                                                                | `10000`   |
+| `RSW_LICENSE`          | License key for Posit Workbench, format should be: `XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX`                      | None      |
+| `RSW_LICENSE_SERVER`   | Floating license server, format should be: `my.url.com:port`                                                 | None      |
+| `RSW_LAUNCHER`         | Whether or not to use launcher locally / start the launcher process                                          | true      |
 | `RSW_LAUNCHER_TIMEOUT` | The timeout, in seconds, to wait for launcher to start listening on the expected port before failing startup | 10        |
 
 ### Ports
 
-| Variable | Description |
-|--------|---|
-| `8787` | Default HTTP Port for RStudio Connect |
-| `5559` | Port for RStudio Launcher server |
+| Variable | Description                           |
+|----------|---------------------------------------|
+| `8787`   | Default HTTP Port for Posit Workbench |
+| `5559`   | Port for Posit Launcher server        |
 
 ### Example usage:
 
@@ -188,12 +288,12 @@ docker run -it \
     rstudio/rstudio-workbench:ubuntu1804
 ```
 
-Open [http://localhost:8787](http://localhost:8787) to access RStudio Workbench.
+Open [http://localhost:8787](http://localhost:8787) to access Posit Workbench.
 The default username and password are `rstudio`.
 
 ### Process Management
 
-In order for RStudio Workbench to function properly, several services need to
+In order for Posit Workbench to function properly, several services need to
 be accounted for. We run these services using
 [`supervisord`](http://supervisord.org/). `supervisord` is an open source
 process supervisor with an active community. It enables running multiple
@@ -201,15 +301,15 @@ services in the container, as well as exiting the container if _any_ of those
 services exit.
 
 > NOTE: generally speaking, running multiple services in a single container is an anti-pattern.
-> However, we have implemented the below as a workaround until RStudio Workbench can
+> However, we have implemented the below as a workaround until Posit Workbench can
 > handle users and other processes in a more container-friendly fashion
 
 Details on the various processes and their configuration is below:
 
-- **RStudio Workbench**: the main server process
+- **Posit Workbench**: the main server process
   - this startup configuration is mounted at `/startup/base`
 
-- **RStudio Job Launcher**: enables launching Jupyter, JupyterLab, and VSCode
+- **Posit Job Launcher**: enables launching Jupyter, JupyterLab, and VSCode
   sessions, as well as talking to job schedulers like Slurm and Kubernetes.
   - Optional and enabled by default
   - this startup configuration is mounted at `/startup/launcher`
@@ -217,7 +317,7 @@ Details on the various processes and their configuration is below:
 
 - **sssd**: often used for user provisioning when connected to an LDAP
   directory or other user store.
-  - Optional, and enabled by default, but with a "dummy" domain so it does
+  - Optional, and enabled by default, but with a "dummy" domain it does
     nothing.
   - To use this with your directory, mount required `.conf` files into
     `/etc/sssd/conf.d/` (more details in `User Provisioning`, above)
@@ -268,9 +368,9 @@ into issues with your license, please do not hesitate to [contact Posit support]
 While neither of these solutions will eliminate the problem, they should help mitigate it. We are still investigating a
 long-term solution.
 
-# Licensing
+# License
 
-The license associated with the RStudio Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
+The license associated with the Posit Docker Products repository is located [in LICENSE.md](https://github.com/rstudio/rstudio-docker-products/blob/main/LICENSE.md).
 
 As is the case with all container images, the images themselves also contain other software which may be under other
 licenses (i.e. bash, linux, system libraries, etc., along with any other direct or indirect dependencies of the primary

--- a/workbench/startup.sh
+++ b/workbench/startup.sh
@@ -49,9 +49,11 @@ if [ -n "$RSP_LICENSE" ]; then
     /usr/lib/rstudio-server/bin/license-manager activate $RSP_LICENSE
 elif [ -n "$RSP_LICENSE_SERVER" ]; then
     /usr/lib/rstudio-server/bin/license-manager license-server $RSP_LICENSE_SERVER
-elif test -f "$RSW_LICENSE_FILE_PATH"; then
+elif test -f "${RSW_LICENSE_FILE_PATH}"; then
     rm -f /var/lib/rstudio-server/*.lic
-    /usr/lib/rstudio-server/bin/license-manager activate-file $RSW_LICENSE_FILE_PATH
+    cp "${RSW_LICENSE_FILE_PATH}" /var/lib/rstudio-server/license.lic
+    chown rstudio-server /var/lib/rstudio-server/license.lic
+    chmod 600 /var/lib/rstudio-server/license.lic
 elif ls /var/lib/rstudio-server/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-server/*.lic."
 fi

--- a/workbench/startup.sh
+++ b/workbench/startup.sh
@@ -49,6 +49,8 @@ if [ -n "$RSP_LICENSE" ]; then
     /usr/lib/rstudio-server/bin/license-manager activate $RSP_LICENSE
 elif [ -n "$RSP_LICENSE_SERVER" ]; then
     /usr/lib/rstudio-server/bin/license-manager license-server $RSP_LICENSE_SERVER
+elif ls /var/lib/rstudio-server/*.lic >/dev/null 2>&1; then
+    echo "Detected a license file in /var/lib/rstudio-server/*.lic."
 elif test -f "$RSW_LICENSE_FILE_PATH"; then
     /usr/lib/rstudio-server/bin/license-manager activate-file $RSW_LICENSE_FILE_PATH
 fi
@@ -58,6 +60,7 @@ unset RSP_LICENSE
 unset RSP_LICENSE_SERVER
 unset RSW_LICENSE
 unset RSW_LICENSE_SERVER
+unset RSW_LICENSE_FILE_PATH
 
 # Create one user
 if [ $(getent passwd $RSW_TESTUSER_UID) ] ; then

--- a/workbench/startup.sh
+++ b/workbench/startup.sh
@@ -44,15 +44,16 @@ RSP_LICENSE=${RSP_LICENSE:-${RSW_LICENSE}}
 RSP_LICENSE_SERVER=${RSP_LICENSE_SERVER:-${RSW_LICENSE_SERVER}}
 
 # Activate License
-RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}
+RSW_LICENSE_FILE_PATH=${RSW_LICENSE_FILE_PATH:-${RSP_LICENSE_FILE_PATH:-/etc/rstudio-server/license.lic}}
 if [ -n "$RSP_LICENSE" ]; then
     /usr/lib/rstudio-server/bin/license-manager activate $RSP_LICENSE
 elif [ -n "$RSP_LICENSE_SERVER" ]; then
     /usr/lib/rstudio-server/bin/license-manager license-server $RSP_LICENSE_SERVER
+elif test -f "$RSW_LICENSE_FILE_PATH"; then
+    rm -f /var/lib/rstudio-server/*.lic
+    /usr/lib/rstudio-server/bin/license-manager activate-file $RSW_LICENSE_FILE_PATH
 elif ls /var/lib/rstudio-server/*.lic >/dev/null 2>&1; then
     echo "Detected a license file in /var/lib/rstudio-server/*.lic."
-elif test -f "$RSW_LICENSE_FILE_PATH"; then
-    /usr/lib/rstudio-server/bin/license-manager activate-file $RSW_LICENSE_FILE_PATH
 fi
 
 # ensure these cannot be inherited by child processes


### PR DESCRIPTION
Closes #734 

- Expand documentation of using license files for product activation in containers.
- Fixes for various broken links.
- Most remaining mentions of "RStudio" replaced with "Posit".
- General refinement and improvement of READMEs for consistency and readability on Docker Hub.