### PR TITLE
Optionally use session-init binary included in components

### DIFF
--- a/workbench-session-init/Dockerfile.ubuntu2204
+++ b/workbench-session-init/Dockerfile.ubuntu2204
@@ -19,23 +19,32 @@ RUN mkdir -p /pwb-staging && \
     mkdir -p /opt/session-components && \
     tar -C /opt/session-components -xpf /pwb-staging/rsp-session-multi-linux.tar.gz && \
     chmod 755 /opt/session-components && \
-    curl -fsSL -o /pwb-staging/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
-    tar -C /usr/local -xf /pwb-staging/go.tar.gz && \
     rm -rf /pwb-staging
 
-# Add Go binary to PATH
-ENV PATH="/usr/local/go/bin:$PATH"
+# Check if session-init binary exists in the tarball, if not build it from source
+RUN if [ -f "/opt/session-components/bin/session-init" ]; then \
+        echo "Using packaged session-init binary"; \
+        mkdir -p /workspace && \
+        cp /opt/session-components/bin/session-init /workspace/entrypoint; \
+    else \
+        echo "Building session-init from source for backwards compatibility"; \
+    fi
 
-# Set the Go workspace
-WORKDIR /workspace
+# Install Go
+RUN if [ ! -f "/workspace/entrypoint" ]; then \
+        echo "Installing Go ${GO_VERSION}"; \
+        curl -fsSL -o /tmp/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" && \
+        tar -C /usr/local -xf /tmp/go.tar.gz; \
+    fi
 
-# Copy the Go source code and download dependencies
-COPY entrypoint/go.mod entrypoint/go.sum ./
-RUN go mod download
-
-# Copy the Go source code and build the binary
-COPY entrypoint/main.go .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w' -o entrypoint main.go
+COPY entrypoint/ /workspace/
+RUN if [ ! -f "/workspace/entrypoint" ]; then \
+        echo "Building entrypoint"; \
+        export PATH=$PATH:/usr/local/go/bin && \
+        cd /workspace && \
+        go mod download && \
+        CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w' -o /workspace/entrypoint main.go; \
+    fi
 
 # Create the final image
 FROM ubuntu:22.04 AS build


### PR DESCRIPTION
With rstudio/rstudio-pro#8394, we now build and package the session init entrypoint with the session components. This PR updates the session init docker file to use this new packaged binary as the entrypoint, but also build it as before for backwards compatibility (mainly for our current 2025.05 release that still needs to build from main).

This should alleviate or pretty much fully fix the platform support issues we had around our release vs. dev builds needing different versions of the init code.