### PR TITLE
Remove `proxy_set_header Host` to fix JupyterLab 500 server errors

### DIFF
--- a/workbench-for-google-cloud-workstations/conf/nginx.site.conf
+++ b/workbench-for-google-cloud-workstations/conf/nginx.site.conf
@@ -1,2 +1,1 @@
 proxy_set_header X-CUSTOM-USER-NAME user/google;
-proxy_set_header Host $http_x_forwarded_host;

--- a/workbench-for-google-cloud-workstations/test/goss.yaml
+++ b/workbench-for-google-cloud-workstations/test/goss.yaml
@@ -99,7 +99,6 @@ file:
     exists: true
     contents:
     - proxy_set_header X-CUSTOM-USER-NAME user/google;
-    - proxy_set_header Host $http_x_forwarded_host;
   /etc/rstudio/vscode.extensions.conf:
     exists: true
     contents:


### PR DESCRIPTION
This setting started to cause 500 errors with JupyterLab for customers because JupyterLab was being passed two hosts in the `Host` header. Removing this line will stop a second host appending to the `Host` header.

The original issues with Code Server CORS functionality from when Workbench for Google Cloud Workstations was originally released have long since been patched. The additional `proxy_set_header Host` line included for the `nginx.site.conf` is no longer required for any reason.