### PR TITLE
Add load flag to docker/bake-action

### DIFF
--- a/.github/actions/bake-test-push/action.yml
+++ b/.github/actions/bake-test-push/action.yml
@@ -123,6 +123,7 @@ runs:
       with:
         targets: "${{ inputs.target }}"
         push: false
+        load: true
         files: ${{ inputs.bakefile }}
 
     - name: Test


### PR DESCRIPTION
This is an attempt to fix inconsistent output of layer digests.

`docker history` was not showing the digets output for images pulled
from Docker Hub or GHCR.

This issue indicates that in order for buildx to output the digests, we
need to set `load: true`
https://github.com/docker/build-push-action/issues/906
