### PR TITLE
Use default Python install, not jupyterlab install

### DIFF
--- a/r-session-complete/Dockerfile.ubuntu2204
+++ b/r-session-complete/Dockerfile.ubuntu2204
@@ -58,7 +58,7 @@ RUN /opt/python/"${PYTHON_VERSION}"/bin/python -m venv /opt/python/jupyter \
     && /opt/python/${PYTHON_VERSION_ALT}/bin/python -m ipykernel install --name py${PYTHON_VERSION_ALT} --display-name "Python ${PYTHON_VERSION_ALT}" \
     && /opt/python/jupyter/bin/python -m pip cache purge
 
-ENV PATH="/opt/python/jupyter/bin:${PATH}"
+ENV PATH="/opt/python/${PYTHON_VERSION}/bin:${PATH}"
 
 COPY vscode.extensions.conf /etc/rstudio/vscode.extensions.conf
 


### PR DESCRIPTION
Brought up in a customer ticket #118720 pointing out that the `jupyter` version of python isn't user-writable so the default python version for this image isn't usable out of the box. 

```
$ which python
/opt/python/jupyter/bin/python
$ pip install scipy
...
Installing collected packages: numpy, scipy
ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/opt/python/jupyter/lib/python3.12/site-packages/numpy'
Check the permissions.
```


This reverts a change to set whatever the `PYTHON_VERSION` is to be the default python version