### PR TITLE
Install `tensorflow_model_server` from upstream image

### DIFF
--- a/connect/Dockerfile.ubuntu2204
+++ b/connect/Dockerfile.ubuntu2204
@@ -19,13 +19,7 @@ RUN HOME="/opt" QUARTO_VERSION=${QUARTO_VERSION} ${SCRIPTS_DIR}/install_quarto.s
 SHELL [ "/bin/bash", "-o", "pipefail", "-c"]
 
 ### Install TensorFlow Serving ###
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal" > /etc/apt/sources.list.d/tensorflow-serving.list && \
-    curl -fsSL https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | apt-key add -
-RUN apt-get update \
-    && apt-get install -yq --no-install-recommends \
-      tensorflow-model-server-universal \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+COPY --from=tensorflow/serving:latest /usr/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 ### Install Connect and additional dependencies ###
 RUN apt-get update --fix-missing \

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,7 @@
+# 2025-08-07
+
+- Install `tensorflow_model_server` binary from the `tensorflow:serving` container image.
+
 # 2025-07-03
 
 - Update documentation with additional license file usage instructions.


### PR DESCRIPTION
Instead of installing the binary from the apt repository, we instead
copy the binary that is built into the upstream container image.

This works around the issue of the annual expiration of the apt
repository key.
