### PR TITLE
Revert "Merge pull request #954 from rstudio/tensorflow-pull-binary-from-image"

### DIFF
--- a/connect/Dockerfile.ubuntu2204
+++ b/connect/Dockerfile.ubuntu2204
@@ -20,7 +20,13 @@ RUN HOME="/opt" QUARTO_VERSION=${QUARTO_VERSION} ${SCRIPTS_DIR}/install_quarto.s
 SHELL [ "/bin/bash", "-o", "pipefail", "-c"]
 
 ### Install TensorFlow Serving ###
-COPY --from=tensorflow/serving:latest /usr/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
+RUN echo "deb [arch=amd64] http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal" > /etc/apt/sources.list.d/tensorflow-serving.list && \
+    curl -fsSL https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | apt-key add -
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends \
+      tensorflow-model-server-universal \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ### Install Connect and additional dependencies ###
 RUN apt-get update --fix-missing \

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,7 @@
+# 2025-09-24
+
+- Revert to installing `tensorflow_model_server` binary from apt repo.
+
 # 2025-08-15
 
 - BREAKING:


### PR DESCRIPTION
This reverts commit 1120f7688eac395657e994c33b7247eb13f40c70, reversing
changes made to 6a2543ba6a224bd93dd10de77fcace588d6fd808.

Install `tensorflow-model-serving` from apt repository instead of using a multistage build and installing the binary from that container.