### PR TITLE
Remove host builder from launcher local plugin if created

### DIFF
--- a/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
+++ b/workbench-for-google-cloud-workstations/Dockerfile.ubuntu2204
@@ -95,7 +95,8 @@ RUN curl -fsSL -o rstudio-workbench.deb "${RSW_DOWNLOAD_URL}/${RSW_NAME}-${RSW_V
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /var/lib/rstudio-server/r-versions
+    && rm -rf /var/lib/rstudio-server/r-versions \
+    && rm -rf /var/lib/rstudio-launcher/Local/jobs/*
 
 ### Install Quarto to PATH ###
 RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto

--- a/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
+++ b/workbench-for-microsoft-azure-ml/Dockerfile.ubuntu2204
@@ -58,7 +58,8 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /var/lib/rstudio-server/r-versions
+    && rm -rf /var/lib/rstudio-server/r-versions \
+    && rm -rf /var/lib/rstudio-launcher/Local/jobs/*
 
 # Workaround to ensure no pre-generated certificates are included in image distributions.
 # This happens in the step immediately following Workbench installation in case the certificates are generated.

--- a/workbench/Dockerfile.ubuntu2204
+++ b/workbench/Dockerfile.ubuntu2204
@@ -63,7 +63,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/lib/rstudio-server/r-versions \
-    && rm -rf /var/lib/rstudio-launcher/Local/jobs/buildkitsandbox
+    && rm -rf /var/lib/rstudio-launcher/Local/jobs/*
 
 # Workaround to ensure no pre-generated certificates are included in image distributions.
 # This happens in the step immediately following Workbench installation in case the certificates are generated.


### PR DESCRIPTION
Adds an `rm` command to remove any local plugin nodes that may have been created by launcher during the Workbench installation for the host builder. This step was already taken in the main `rstudio/rstudio-workbench` image, but I generalized it since the builder may not necessarily always identify as `buildkitsandbox` in other contexts.