### PR TITLE
chore: consistent indentation in connect/startup.sh

### DIFF
--- a/connect/startup.sh
+++ b/connect/startup.sh
@@ -2,7 +2,7 @@
 
 set -e
 if [[ "${STARTUP_DEBUG_MODE:-0}" -eq 1 ]]; then
-  set -x
+    set -x
 fi
 
 # Deactivate license when it exists
@@ -11,20 +11,20 @@ deactivate() {
     is_deactivated=0
     retries=0
     while [[ $is_deactivated -ne 1 ]] && [[ $retries -le 3 ]]; do
-      /opt/rstudio-connect/bin/license-manager deactivate >/dev/null 2>&1
-      is_deactivated=1
-      ((retries+=1))
-      for file in $(ls -A /var/lib/.local); do
-        if [ -s /var/lib/.local/$file ]; then
-          if [[ $retries -lt 3 ]]; then
-            echo "License did not deactivate, retry ${retries}..."
-            is_deactivated=0
-          else
-            echo "Unable to deactivate license. If you encounter issues activating your product in the future, please contact Posit support."
-          fi
-          continue
-        fi
-      done
+        /opt/rstudio-connect/bin/license-manager deactivate >/dev/null 2>&1
+        is_deactivated=1
+        ((retries+=1))
+        for file in $(ls -A /var/lib/.local); do
+            if [ -s /var/lib/.local/$file ]; then
+                if [[ $retries -lt 3 ]]; then
+                    echo "License did not deactivate, retry ${retries}..."
+                    is_deactivated=0
+                else
+                    echo "Unable to deactivate license. If you encounter issues activating your product in the future, please contact Posit support."
+                fi
+                continue
+            fi
+        done
     done
 }
 


### PR DESCRIPTION
Connect had a mix of two and four space indentation. Consistently use four space indentation.

Making this change only because it helps keep it in sync with other, external startup scripts which used consistent indentation.

No functional change.

```bash
git diff -w main
```