### PR TITLE
fix: create docker safe tag for new versioning scheme including +

### DIFF
--- a/docker-bake.preview.hcl
+++ b/docker-bake.preview.hcl
@@ -264,7 +264,7 @@ target "package-manager-preview" {
     inherits = ["base"]
     target = "build"
 
-    name = "package-manager-preview-${builds.os}-${replace(PACKAGE_MANAGER_PREVIEW_VERSION, ".", "-")}"
+    name = "package-manager-preview-${builds.os}-${replace(tag_safe_version(PACKAGE_MANAGER_PREVIEW_VERSION), ".", "-")}"
     tags = get_tags(builds.os, "rstudio-package-manager-preview", PACKAGE_MANAGER_PREVIEW_VERSION, "preview")
 
     dockerfile = "Dockerfile.${builds.os}"
@@ -287,7 +287,7 @@ target "package-manager-daily" {
     inherits = ["base"]
     target = "build"
 
-    name = "package-manager-daily-${builds.os}-${replace(PACKAGE_MANAGER_DAILY_VERSION, ".", "-")}"
+    name = "package-manager-daily-${builds.os}-${replace(tag_safe_version(PACKAGE_MANAGER_DAILY_VERSION), ".", "-")}"
     tags = get_tags(builds.os, "rstudio-package-manager-preview", PACKAGE_MANAGER_DAILY_VERSION, "daily")
 
     dockerfile = "Dockerfile.${builds.os}"

--- a/package-manager/Dockerfile.ubuntu2204
+++ b/package-manager/Dockerfile.ubuntu2204
@@ -21,13 +21,15 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
 # Download RStudio Package Manager ---------------------------------------------#
 ARG RSPM_VERSION
 ARG RSPM_DOWNLOAD_URL=https://cdn.rstudio.com/package-manager/deb/amd64
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3015
-RUN curl -fsSL -O ${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION}_amd64.deb \
+RUN RSPM_VERSION_URL=$(echo -n "${RSPM_VERSION}" | sed 's/+/%2B/g') \
+    && curl -fsSL -o rstudio-pm.deb "${RSPM_DOWNLOAD_URL}/rstudio-pm_${RSPM_VERSION_URL}_amd64.deb" \
     # Post 7/25 packages
     && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
-    && dpkg-sig --verify rstudio-pm_${RSPM_VERSION}_amd64.deb \
-    && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 apt-get install -y ./rstudio-pm_${RSPM_VERSION}_amd64.deb \
-    && rm rstudio-pm_${RSPM_VERSION}_amd64.deb \
+    && dpkg-sig --verify rstudio-pm.deb \
+    && RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1 apt-get install -y ./rstudio-pm.deb \
+    && rm rstudio-pm.deb \
     && (ln -s /opt/rstudio-pm/bin/rspm /usr/local/bin/rspm || echo "/usr/local/bin/rspm symlink already exists")
 
 # Add run script and set permissions -------------------------------------------#


### PR DESCRIPTION
Package Manager has switched to a versioning scheme that matches Connect based on `git describe`:
```
2026.01.0-dev+161-g69d857cc89
```

We previously did not have a `+` sign in our version, but now that we do we need to convert it to `-` like Connect to make a Docker safe tag.

This also now properly handles the URL encoding of `+` to `%2B` when downloading the DEB in the Dockerfile like Connect does.

The Docker build pipeline is broken until this is merged:
https://github.com/rstudio/rstudio-docker-products/actions/runs/20997080226/job/60356613772


Ref https://github.com/rstudio/package-manager/issues/16478