### PR TITLE
remove virtualenv

### DIFF
--- a/content/base/NEWS.md
+++ b/content/base/NEWS.md
@@ -1,3 +1,7 @@
+# 2026-02-23
+
+- Remove `virtualenv`
+
 # 2025-11-05
 
 - Remove outdated default values for `ARG` instructions related to versions.

--- a/product/base/deps/requirements.txt
+++ b/product/base/deps/requirements.txt
@@ -1,4 +1,3 @@
 pip
 setuptools
-virtualenv
 wheel>=0.38.0

--- a/product/base/scripts/ubuntu/install_python.sh
+++ b/product/base/scripts/ubuntu/install_python.sh
@@ -97,7 +97,6 @@ install_python() {
     $PYTHON_BIN -m ensurepip --upgrade
     $PYTHON_BIN -m pip install -U setuptools
     $PYTHON_BIN -m pip install -U pip
-    $PYTHON_BIN -m pip install -U virtualenv
 }
 
 install_python_packages() {


### PR DESCRIPTION
Environments running automated Connect System Checks may fail tests if unnecessary packages are installed in the global python library. `virtualenv` is not required for any Posit Team functionality.