### PR TITLE
Fix positron-init glob and add 2026.04.0

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -184,6 +184,7 @@ variable WORKBENCH_SESSION_INIT_BUILD_MATRIX {
 variable WORKBENCH_POSITRON_INIT_BUILD_MATRIX {
     default = {
         builds = [
+            {os = "ubuntu2204", positron_version = "2026.04.0-269"},
             {os = "ubuntu2204", positron_version = "2026.03.0-212"},
             {os = "ubuntu2204", positron_version = "2026.02.1-5"},
         ]

--- a/workbench-positron-init/Dockerfile.ubuntu2204
+++ b/workbench-positron-init/Dockerfile.ubuntu2204
@@ -15,7 +15,7 @@ RUN mkdir -p /opt/positron/bin/positron-server && \
     curl -fsSL -o /tmp/positron-server.tar.gz \
       "https://cdn.posit.co/positron/releases/pwb/x86_64/positron-workbench-linux-x64-${POSITRON_VERSION}.tar.gz" && \
     tar -xzf /tmp/positron-server.tar.gz -C /tmp && \
-    mv /tmp/vscode-reh-web-linux-x64 /opt/positron/bin/positron-server/bundled && \
+    mv /tmp/vscode-reh-web-*linux-x64 /opt/positron/bin/positron-server/bundled && \
     rm /tmp/positron-server.tar.gz
 
 # Download Positron docs


### PR DESCRIPTION
## Summary

- The 2026.04.0-269 Positron release renamed the extracted tarball directory from `vscode-reh-web-linux-x64` to `vscode-reh-web-pwb-linux-x64`, which will break the `mv` in the Dockerfile
- Widen the `mv` target from a hardcoded path to a glob (`vscode-reh-web-*linux-x64`) to handle both naming conventions
- Add `2026.04.0-269` to the positron-init build matrix

## Test plan

- [x] CI builds `workbench-positron-init:2026.04.0-269` successfully
- [x] Existing versions (`2026.03.0-212`, `2026.02.1-5`) still build with the widened glob