### PR TITLE
Add Positron version 2026.05.0-179 to Workbench Positron Init build matrix

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -184,6 +184,7 @@ variable WORKBENCH_SESSION_INIT_BUILD_MATRIX {
 variable WORKBENCH_POSITRON_INIT_BUILD_MATRIX {
     default = {
         builds = [
+            {os = "ubuntu2204", positron_version = "2026.05.0-179"},
             {os = "ubuntu2204", positron_version = "2026.04.0-269"},
             {os = "ubuntu2204", positron_version = "2026.03.0-212"},
             {os = "ubuntu2204", positron_version = "2026.02.1-5"},


### PR DESCRIPTION
## Summary

Positron released 2025.05.0-179: https://cdn.posit.co/positron/releases/pwb/x86_64/all-releases.json

Add 2025.05.0-179 to the positron-init build matrix

## Test Plan

- [ ] CI builds workbench-positron-init:2025.05.0-179 successfully
- [x] local test passed:
```bash
GIT_SHA=$(git rev-parse --short HEAD) docker buildx bake -f docker-bake.hcl workbench-positron-init-ubuntu2204-2026-05-0-179
just test workbench-positron-init
```
