### PR TITLE
docs: Point Docker README licensing sections at the trial form

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -134,7 +134,7 @@ docker run -it --privileged \
 
 ### Product Licensing
 
-Using the Posit Connect docker image requires you to have a valid License. Posit recommends using [license file activation](#example-usage-with-a-license-file) rather than license key activation. License files work well in all environments including ephemeral, container-based, or air-gapped environments. See the [Licensing FAQ](https://docs.posit.co/licensing/licensing-faq.html) for more details. For full details and information about license key activation, see the [Licensing](https://docs.posit.co/connect/admin/licensing/) page. You can set the license three different ways: 
+Using the Posit Connect docker image requires you to have a valid License. If you don't have a license yet, request a free 30-day trial at [posit.co/trial-license](https://posit.co/trial-license/). Posit recommends using [license file activation](#example-usage-with-a-license-file) rather than license key activation. License files work well in all environments including ephemeral, container-based, or air-gapped environments. See the [Licensing FAQ](https://docs.posit.co/licensing/licensing-faq.html) for more details. For full details and information about license key activation, see the [Licensing](https://docs.posit.co/connect/admin/licensing/) page. You can set the license three different ways: 
 
 1. Mounting a `/var/lib/rstudio-connect/*.lic` single file that contains a valid license for Posit Connect
 2. Setting the `RSC_LICENSE` environment variable to a valid license key inside the container

--- a/package-manager/Dockerfile.ubuntu2204
+++ b/package-manager/Dockerfile.ubuntu2204
@@ -46,8 +46,8 @@ COPY rstudio-pm.gcfg /etc/rstudio-pm/rstudio-pm.gcfg
 
 # Set up licensing to work in userspace mode. This will not prevent activating a
 # license as root, but it is required to activate one as the non-root user at
-# runtime. It's possible for this to fail and the trial will be considered over,
-# in which case we can ignore it anyway.
+# runtime. It's possible for this to fail, in which case license activation can
+# be retried later and we can ignore the initialization failure.
 RUN license-manager initialize --userspace || true
 
 ENTRYPOINT ["tini", "--"]

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -102,7 +102,7 @@ DataDir = /mnt/rspm/data
 
 ### Product Licensing
 
-Using the Posit Package Manager docker image requires you to have a valid License. Posit recommends using [license file activation](#example-usage-with-a-license-file) rather than license key activation. License files work well in all environments including ephemeral, container-based, or air-gapped environments. See the [Licensing FAQ](https://docs.posit.co/licensing/licensing-faq.html) for more details. For full details and information about license key activation, see the [Licensing](https://docs.posit.co/rspm/admin/licensing/) page. You can set the license three different ways:
+Using the Posit Package Manager docker image requires you to have a valid License. If you don't have a license yet, request a free 30-day trial at [posit.co/trial-license](https://posit.co/trial-license/). Posit recommends using [license file activation](#example-usage-with-a-license-file) rather than license key activation. License files work well in all environments including ephemeral, container-based, or air-gapped environments. See the [Licensing FAQ](https://docs.posit.co/licensing/licensing-faq.html) for more details. For full details and information about license key activation, see the [Licensing](https://docs.posit.co/rspm/admin/licensing/) page. You can set the license three different ways:
 
 1. Mounting a license file at `/var/lib/rstudio-pm/*.lic` or `/home/rstudio-pm/.rstudio-pm/*.lic` or a different path specified using `RSPM_LICENSE_FILE_PATH` that contains a valid license for Posit Package Manager
 2. Setting the `RSPM_LICENSE` environment variable to a valid license key inside the container

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -117,7 +117,7 @@ machine or your docker orchestration system.
 
 ### Product Licensing
 
-Using the Posit Workbench docker image requires you to have a valid License. Posit recommends using [license file activation](#example-usage-with-a-license-file) rather than license key activation. License files work well in all environments including ephemeral, container-based, or air-gapped environments. See the [Licensing FAQ](https://docs.posit.co/licensing/licensing-faq.html) for more details. For full details and information about license key activation, see the [Licensing](https://docs.posit.co/ide/server-pro/admin/license_management/license_management.html) page. You can set the license three different ways:
+Using the Posit Workbench docker image requires you to have a valid License. If you don't have a license yet, request a free 30-day trial at [posit.co/trial-license](https://posit.co/trial-license/). Posit recommends using [license file activation](#example-usage-with-a-license-file) rather than license key activation. License files work well in all environments including ephemeral, container-based, or air-gapped environments. See the [Licensing FAQ](https://docs.posit.co/licensing/licensing-faq.html) for more details. For full details and information about license key activation, see the [Licensing](https://docs.posit.co/ide/server-pro/admin/license_management/license_management.html) page. You can set the license three different ways:
 
 1. Mounting a license file at `/var/lib/rstudio-server/*.lic` or a different path specified using `RSW_LICENSE_FILE_PATH` that contains a valid license for Posit Workbench
 2. Setting the `RSW_LICENSE` environment variable to a valid license key inside the container


### PR DESCRIPTION
## Summary

The Connect, Workbench, and Package Manager Docker READMEs (rendered as the description on Docker Hub) tell first-time users that they need a "valid License" but never say where to get one. With the built-in 45-day trial removed under [Project Gateway](https://posit.co/trial-license/), this PR adds a one-sentence pointer to <https://posit.co/trial-license/> in each README's *Product Licensing* intro.

It also reworks a stale comment in `package-manager/Dockerfile.ubuntu2204` that referenced the built-in trial; the new wording preserves the operational meaning (userspace init can fail; activation can be retried) without referencing trials.

## Changes

| File | Change |
|---|---|
| `connect/README.md` | Add trial-license pointer sentence to Product Licensing intro |
| `workbench/README.md` | Same |
| `package-manager/README.md` | Same |
| `package-manager/Dockerfile.ubuntu2204` | Rework line-49 comment to drop trial reference |

## What's left as-is

The example `license-manager status` output (with `Has-Trial` / `Trial-Type` lines) is unchanged. The binary still prints those fields during the 7-day transitional period, so the example is still accurate. Best to revisit when the binary output itself changes.

## Cross-references

- Tracking: TWPM-434 — Documentation updates for Project Gateway
- Wave 2 PRs already in flight: posit-dev/connect#39378 (approved), rstudio/package-manager#17931, rstudio/rstudio-pro#11013

Closes #1036