### PR TITLE
Add Node.js support to Connect image

### DIFF
--- a/connect/Dockerfile.ubuntu2204
+++ b/connect/Dockerfile.ubuntu2204
@@ -6,6 +6,8 @@ ARG R_VERSION
 ARG R_VERSION_ALT
 ARG PYTHON_VERSION
 ARG PYTHON_VERSION_ALT
+ARG NODEJS_VERSION
+ARG NODEJS_VERSION_ALT
 ARG RSC_VERSION
 ARG QUARTO_VERSION
 ARG SCRIPTS_DIR=/opt/positscripts
@@ -18,6 +20,11 @@ COPY --chmod=0775 startup.sh /usr/local/bin/startup.sh
 # TODO: Remove `HOME="/opt"` once Quarto supports custom install locations for TinyTeX, see quarto-dev/quarto-cli#11800.
 RUN HOME="/opt" QUARTO_VERSION=${QUARTO_VERSION} ${SCRIPTS_DIR}/install_quarto.sh --install-tinytex --add-path-tinytex \
     && ln -s /opt/quarto/${QUARTO_VERSION}/bin/quarto /usr/local/bin/quarto
+
+### Install Node.js ###
+RUN NODEJS_VERSION=${NODEJS_VERSION} ${SCRIPTS_DIR}/install_node.sh \
+    && NODEJS_VERSION=${NODEJS_VERSION_ALT} ${SCRIPTS_DIR}/install_node.sh \
+    && ln -s /opt/nodejs/${NODEJS_VERSION} /opt/nodejs/default
 
 ### Install TensorFlow Serving ###
 # TODO: Reenable TensorFlow Serving once the issue with bucket access is resolved, see https://github.com/tensorflow/serving/issues/4131
@@ -54,7 +61,9 @@ ENV STARTUP_DEBUG_MODE 0
 COPY rstudio-connect.gcfg /etc/rstudio-connect/rstudio-connect.gcfg
 RUN sed -i "s/{{PYTHON_VERSION}}/${PYTHON_VERSION}/g" /etc/rstudio-connect/rstudio-connect.gcfg \
     && sed -i "s/{{PYTHON_VERSION_ALT}}/${PYTHON_VERSION_ALT}/g" /etc/rstudio-connect/rstudio-connect.gcfg \
-    && sed -i "s/{{QUARTO_VERSION}}/${QUARTO_VERSION}/g" /etc/rstudio-connect/rstudio-connect.gcfg
+    && sed -i "s/{{QUARTO_VERSION}}/${QUARTO_VERSION}/g" /etc/rstudio-connect/rstudio-connect.gcfg \
+    && sed -i "s/{{NODEJS_VERSION}}/${NODEJS_VERSION}/g" /etc/rstudio-connect/rstudio-connect.gcfg \
+    && sed -i "s/{{NODEJS_VERSION_ALT}}/${NODEJS_VERSION_ALT}/g" /etc/rstudio-connect/rstudio-connect.gcfg
 VOLUME ["/data"]
 
 ENTRYPOINT ["tini", "--"]

--- a/connect/NEWS.md
+++ b/connect/NEWS.md
@@ -1,3 +1,10 @@
+# 2026-05-11
+
+- Add Node.js 24.15.0 and 22.22.2 to the image. Node.js support in Connect is
+  an Early Access feature in 2026.04.0 and is disabled by default. See the
+  commented `[NodeJs]` and `[EarlyAccess]` blocks in `rstudio-connect.gcfg`
+  for an example of how to enable it.
+
 # 2026-02-25
 
 - Temporarily disable TensorFlow Serving due to issues with the bucket access permissions for install.

--- a/connect/rstudio-connect.gcfg
+++ b/connect/rstudio-connect.gcfg
@@ -37,6 +37,17 @@ Executable = /opt/python/{{PYTHON_VERSION_ALT}}/bin/python
 Enabled = true
 Executable = /opt/quarto/{{QUARTO_VERSION}}/bin/quarto
 
+; To enable Node.js content support (Early Access, Connect 2026.04.0+),
+; uncomment the [NodeJs] and [EarlyAccess] sections below.
+;
+; [NodeJs]
+; Enabled = true
+; Executable = /opt/nodejs/{{NODEJS_VERSION}}/bin/node
+; Executable = /opt/nodejs/{{NODEJS_VERSION_ALT}}/bin/node
+;
+; [EarlyAccess]
+; NodeJs = true
+
 ; [TensorFlow]
 ; Enabled = true
 ; Executable = /usr/bin/tensorflow_model_server

--- a/connect/test/goss.yaml
+++ b/connect/test/goss.yaml
@@ -47,6 +47,13 @@ file:
     exists: true
   /opt/python/{{.Env.PYTHON_VERSION_ALT}}/bin/python:
     exists: true
+  /opt/nodejs/{{.Env.NODEJS_VERSION}}/bin/node:
+    exists: true
+  /opt/nodejs/{{.Env.NODEJS_VERSION_ALT}}/bin/node:
+    exists: true
+  /opt/nodejs/default:
+    exists: true
+    filetype: symlink
   /opt/quarto/{{.Env.QUARTO_VERSION}}/bin/quarto:
     exists: true
   /usr/local/bin/quarto:
@@ -126,6 +133,20 @@ command:
     exit-status: 0
     stdout: [
       "{{ .Env.PYTHON_VERSION_ALT }}"
+    ]
+
+# Ensure correct Node.js version
+  "/opt/nodejs/{{ .Env.NODEJS_VERSION }}/bin/node --version":
+    title: nodejs_version_matches
+    exit-status: 0
+    stdout: [
+      "{{ .Env.NODEJS_VERSION }}"
+    ]
+  "/opt/nodejs/{{ .Env.NODEJS_VERSION_ALT }}/bin/node --version":
+    title: nodejs_version_matches
+    exit-status: 0
+    stdout: [
+      "{{ .Env.NODEJS_VERSION_ALT }}"
     ]
 
 # Ensure correct Quarto version

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -104,7 +104,7 @@ variable PACKAGE_MANAGER_BUILD_MATRIX {
 variable CONNECT_BUILD_MATRIX {
     default = {
         builds = [
-            {os = "ubuntu2204", r_primary = "4.5.2", r_alternate = "4.4.3", py_primary = "3.13.9", py_alternate = "3.12.11", quarto = "1.8.25"},
+            {os = "ubuntu2204", r_primary = "4.5.2", r_alternate = "4.4.3", py_primary = "3.13.9", py_alternate = "3.12.11", nodejs_primary = "24.15.0", nodejs_alternate = "22.22.2", quarto = "1.8.25"},
         ]
     }
 }
@@ -326,6 +326,8 @@ target "connect" {
         R_VERSION_ALT = builds.r_alternate
         PYTHON_VERSION = builds.py_primary
         PYTHON_VERSION_ALT = builds.py_alternate
+        NODEJS_VERSION = builds.nodejs_primary
+        NODEJS_VERSION_ALT = builds.nodejs_alternate
         RSC_VERSION = CONNECT_VERSION
         QUARTO_VERSION = builds.quarto
     }

--- a/docker-bake.preview.hcl
+++ b/docker-bake.preview.hcl
@@ -125,7 +125,7 @@ variable PACKAGE_MANAGER_BUILD_MATRIX {
 variable CONNECT_BUILD_MATRIX {
     default = {
         builds = [
-            {os = "ubuntu2204", r_primary = "4.5.2", r_alternate = "4.4.3", py_primary = "3.13.9", py_alternate = "3.12.12", quarto = "1.8.25"},
+            {os = "ubuntu2204", r_primary = "4.5.2", r_alternate = "4.4.3", py_primary = "3.13.9", py_alternate = "3.12.12", nodejs_primary = "24.15.0", nodejs_alternate = "22.22.2", quarto = "1.8.25"},
         ]
     }
 }

--- a/docker-bake.preview.hcl
+++ b/docker-bake.preview.hcl
@@ -326,6 +326,8 @@ target "connect-daily" {
         R_VERSION_ALT = builds.r_alternate
         PYTHON_VERSION = builds.py_primary
         PYTHON_VERSION_ALT = builds.py_alternate
+        NODEJS_VERSION = builds.nodejs_primary
+        NODEJS_VERSION_ALT = builds.nodejs_alternate
         RSC_VERSION = CONNECT_DAILY_VERSION
         QUARTO_VERSION = builds.quarto
     }

--- a/product/base/scripts/ubuntu/install_node.sh
+++ b/product/base/scripts/ubuntu/install_node.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -eo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+# Output delimiter
+d="===="
+
+usage() {
+    echo "Usage:"
+    echo "  $0 [OPTIONS]"
+    echo ""
+    echo "Examples:"
+    echo "  # Install Node.js version specified by NODEJS_VERSION environment variable"
+    echo "  $0"
+    echo "  # Install Node.js 22.22.2"
+    echo "  NODEJS_VERSION=22.22.2 $0"
+    echo ""
+    echo "Options:"
+    echo "  -d, --debug         Enable debug output"
+    echo "  -h, --help          Print usage and exit"
+    echo "      --prefix        Install Node.js to a custom prefix"
+    echo "                      Each version of Node.js will have its own subdirectory"
+    echo "                      Default: /opt/nodejs"
+}
+
+# Set defaults
+PREFIX="/opt/nodejs"
+
+OPTIONS=$(getopt -o hd --long help,debug,prefix: -- "$@")
+# shellcheck disable=SC2181
+if [[ $? -ne 0 ]]; then
+    exit 1;
+fi
+
+eval set -- "$OPTIONS"
+while true; do
+    case "$1" in
+        -d | --debug)
+            set -x
+            shift
+            ;;
+        -h | --help)
+            usage
+            shift
+            exit
+            ;;
+        --prefix)
+            PREFIX="$2"
+            shift 2
+            ;;
+        --) shift;
+            break
+            ;;
+    esac
+done
+
+if [ -z "$NODEJS_VERSION" ]; then
+    usage
+    exit 1
+fi
+
+# Set node binary path
+NODE_BIN="${PREFIX}/${NODEJS_VERSION}/bin/node"
+
+install_node() {
+    # Check if Node.js is already installed at the requested version.
+    if [ -x "$NODE_BIN" ] && "$NODE_BIN" --version | grep -qE "^v${NODEJS_VERSION}$"; then
+        echo "$d Node.js $NODEJS_VERSION is already installed in $PREFIX/$NODEJS_VERSION $d"
+        return
+    fi
+
+    echo "$d$d Installing Node.js $NODEJS_VERSION to $PREFIX/$NODEJS_VERSION $d$d"
+    mkdir -p "$PREFIX/$NODEJS_VERSION"
+
+    local tarball="node-v${NODEJS_VERSION}-linux-x64.tar.xz"
+    local base_url="https://nodejs.org/dist/v${NODEJS_VERSION}"
+
+    curl -fsSL -o "/tmp/${tarball}" "${base_url}/${tarball}"
+    curl -fsSL -o /tmp/SHASUMS256.txt "${base_url}/SHASUMS256.txt"
+
+    # Verify checksum: extract just our tarball's line and pipe to sha256sum -c.
+    (cd /tmp && grep " ${tarball}\$" SHASUMS256.txt | sha256sum -c -)
+
+    tar -xJf "/tmp/${tarball}" -C "$PREFIX/$NODEJS_VERSION" --strip-components=1
+
+    rm -f "/tmp/${tarball}" /tmp/SHASUMS256.txt
+}
+
+install_node


### PR DESCRIPTION
Adds Node.js to the `rstudio-connect`image.

Two Node.js version are included:
- LTS `24.15.0` as the primary
- LTS `22.22.2` as the alternate

Node.js support remained disabled by default in the Connect configuration since it is an Early Access feature.

Resolves #1034.

Off-host execution support for Node in `content/base` / `content/pro` will follow in a separate PR.

## Approach

- `product/base/scripts/ubuntu/install_node.sh` downloads the official linux-x64 tarball from `nodejs.org`, verifies the SHA-256 against `SHASUMS256.txt`, and extracts to `/opt/nodejs/<version>/`. Idempotent on re-run. Structurally mirrors the sibling `install_python.sh`.
- `docker-bake.hcl` `CONNECT_BUILD_MATRIX` gains `nodejs_primary` and `nodejs_alternate` fields; the `connect` target passes them as `NODEJS_VERSION` / `NODEJS_VERSION_ALT` build args.
- `connect/Dockerfile.ubuntu2204` invokes the install script twice (one per version) and symlinks `/opt/nodejs/default -> /opt/nodejs/${NODEJS_VERSION}`. Two new `sed` substitutions fill `{{NODEJS_VERSION}}` placeholders in the gcfg at build time.
- `connect/rstudio-connect.gcfg` gains a commented `[NodeJs]` + `[EarlyAccess]` block. The commented `[TensorFlow]` block already in the file is the precedent.
- `connect/test/goss.yaml` gains file + symlink + version-command checks. The test runner (`tools/test_bake_artifacts.py:62`) auto-injects bake args as `--env` flags, so no test-harness changes were required.