### PR TITLE
Update TinyTeX install URL to tinytex.yihui.org

### DIFF
--- a/content/base/Dockerfile.ubuntu2204
+++ b/content/base/Dockerfile.ubuntu2204
@@ -88,7 +88,7 @@ RUN apt-get update \
 RUN apt-get update  \
     && apt-get install -y --no-install-recommends wget \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL "https://yihui.org/tinytex/install-bin-unix.sh" | sh \
+    && curl -fsSL "https://tinytex.yihui.org/install-bin-unix.sh" | sh \
     && /root/.TinyTeX/bin/*/tlmgr path remove \
     && mv /root/.TinyTeX/ /opt/TinyTeX \
     && /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin \


### PR DESCRIPTION
## Summary

Updates `content/base/Dockerfile.ubuntu2204` to fetch the TinyTeX install script from `tinytex.yihui.org` directly instead of going through `yihui.org/tinytex/install-bin-unix.sh`.

## Why

Per the [TinyTeX FAQ](https://yihui.org/tinytex/faq/), the canonical install URL has moved to `tinytex.yihui.org`. The old URL is now a 301 redirect to the new one, but the redirect host has been returning intermittent HTTP 500s — which fails the content-base build under `curl -fsSL`'s strict error handling.

Verified locally:

```
$ curl -sI https://yihui.org/tinytex/install-bin-unix.sh | head -1
HTTP/2 301
$ curl -sI https://tinytex.yihui.org/install-bin-unix.sh | head -1
HTTP/2 200
```

Pointing directly at the new host removes the redirect hop and the flaky old host from the critical path.