### PR TITLE
Update note to reflect GA of posit-dev/images

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Docker images for RStudio Professional Products
 
 > [!NOTE]
-> New Posit container images are in preview at [posit-dev/images](https://github.com/posit-dev/images) and will eventually replace this repository.
+> The new Posit container images at [posit-dev/images](https://github.com/posit-dev/images) are now generally available and will replace this repository.
 >
-> - These images continue to be maintained.
-> - No deprecation date will be set until the new images are generally available.
+> - These images continue to be maintained during the transition.
+> - A deprecation date will be announced separately.
 >
 > See [Image Migration](#image-migration) for the mapping between current and new images. Questions and feedback are welcome on [GitHub Discussions](https://github.com/posit-dev/images/discussions).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Docker images for RStudio Professional Products
 
 > [!NOTE]
-> The new Posit container images at [posit-dev/images](https://github.com/posit-dev/images) are now generally available and will replace this repository.
+> The new Posit container images at [posit-dev/images](https://github.com/posit-dev/images) are now generally available and replace this repository.
 >
 > - These images continue to be maintained during the transition.
 > - A deprecation date will be announced separately.

--- a/connect-content-init/README.md
+++ b/connect-content-init/README.md
@@ -1,11 +1,11 @@
 # Quick reference
 
 > [!NOTE]
-> A new [posit/connect-content-init](https://github.com/posit-dev/images-connect/blob/main/connect-content-init/README.md) image is in preview and will eventually replace this image.
+> A new <a href="https://github.com/posit-dev/images-connect/blob/main/connect-content-init/README.md">posit/connect-content-init</a> image is now generally available and replaces this image.
 >
-> - This image continues to be maintained. No deprecation date will be set until the new image is generally available.
+> - This image continues to be maintained. A deprecation date will be announced separately.
 >
-> New image: [Docker Hub](https://hub.docker.com/r/posit/connect-content-init) | [GHCR](https://github.com/posit-dev/images-connect/pkgs/container/connect-content-init) | [GitHub](https://github.com/posit-dev/images-connect) | [Discussions](https://github.com/posit-dev/images/discussions)
+> New image: <a href="https://hub.docker.com/r/posit/connect-content-init">Docker Hub</a> | <a href="https://github.com/posit-dev/images-connect/pkgs/container/connect-content-init">GHCR</a> | <a href="https://github.com/posit-dev/images-connect">GitHub</a> | <a href="https://github.com/posit-dev/images/discussions">Discussions</a>
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
 * Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), [the Posit Connect Documentation](https://docs.posit.co/connect/), 

--- a/connect/README.md
+++ b/connect/README.md
@@ -1,11 +1,11 @@
 # Quick reference
 
 > [!NOTE]
-> A new [posit/connect](https://github.com/posit-dev/images-connect/blob/main/connect/README.md) image is in preview and will eventually replace this image.
+> A new <a href="https://github.com/posit-dev/images-connect/blob/main/connect/README.md">posit/connect</a> image is now generally available and replaces this image.
 >
-> - This image continues to be maintained. No deprecation date will be set until the new image is generally available.
+> - This image continues to be maintained. A deprecation date will be announced separately.
 >
-> New image: [Docker Hub](https://hub.docker.com/r/posit/connect) | [GHCR](https://github.com/posit-dev/images-connect/pkgs/container/connect) | [GitHub](https://github.com/posit-dev/images-connect) | [Discussions](https://github.com/posit-dev/images/discussions)
+> New image: <a href="https://hub.docker.com/r/posit/connect">Docker Hub</a> | <a href="https://github.com/posit-dev/images-connect/pkgs/container/connect">GHCR</a> | <a href="https://github.com/posit-dev/images-connect">GitHub</a> | <a href="https://github.com/posit-dev/images/discussions">Discussions</a>
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
 * Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 

--- a/content/README.md
+++ b/content/README.md
@@ -1,11 +1,11 @@
 ## content/base
 
 > [!NOTE]
-> A new [posit/connect-content](https://github.com/posit-dev/images-connect/blob/main/connect-content/README.md) image is in preview and will eventually replace these images.
+> A new <a href="https://github.com/posit-dev/images-connect/blob/main/connect-content/README.md">posit/connect-content</a> image is now generally available and replaces these images.
 >
-> - These images continue to be maintained. No deprecation date will be set until the new image is generally available.
+> - These images continue to be maintained. A deprecation date will be announced separately.
 >
-> New image: [Docker Hub](https://hub.docker.com/r/posit/connect-content) | [GHCR](https://github.com/posit-dev/images-connect/pkgs/container/connect-content) | [GitHub](https://github.com/posit-dev/images-connect) | [Discussions](https://github.com/posit-dev/images/discussions)
+> New image: <a href="https://hub.docker.com/r/posit/connect-content">Docker Hub</a> | <a href="https://github.com/posit-dev/images-connect/pkgs/container/connect-content">GHCR</a> | <a href="https://github.com/posit-dev/images-connect">GitHub</a> | <a href="https://github.com/posit-dev/images/discussions">Discussions</a>
 
 This is a basic image with:
 

--- a/package-manager/README.md
+++ b/package-manager/README.md
@@ -1,11 +1,11 @@
 # Quick reference
 
 > [!NOTE]
-> A new [posit/package-manager](https://github.com/posit-dev/images-package-manager/blob/main/package-manager/README.md) image is in preview and will eventually replace this image.
+> A new <a href="https://github.com/posit-dev/images-package-manager/blob/main/package-manager/README.md">posit/package-manager</a> image is now generally available and replaces this image.
 >
-> - This image continues to be maintained. No deprecation date will be set until the new image is generally available.
+> - This image continues to be maintained. A deprecation date will be announced separately.
 >
-> New image: [Docker Hub](https://hub.docker.com/r/posit/package-manager) | [GHCR](https://github.com/posit-dev/images-package-manager/pkgs/container/package-manager) | [GitHub](https://github.com/posit-dev/images-package-manager) | [Discussions](https://github.com/posit-dev/images/discussions)
+> New image: <a href="https://hub.docker.com/r/posit/package-manager">Docker Hub</a> | <a href="https://github.com/posit-dev/images-package-manager/pkgs/container/package-manager">GHCR</a> | <a href="https://github.com/posit-dev/images-package-manager">GitHub</a> | <a href="https://github.com/posit-dev/images/discussions">Discussions</a>
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
 * Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 

--- a/r-session-complete/README.md
+++ b/r-session-complete/README.md
@@ -1,11 +1,11 @@
 # Quick reference
 
 > [!NOTE]
-> A new [posit/workbench-session](https://github.com/posit-dev/images-workbench/blob/main/workbench-session/README.md) image is in preview and will eventually replace this image.
+> A new <a href="https://github.com/posit-dev/images-workbench/blob/main/workbench-session/README.md">posit/workbench-session</a> image is now generally available and replaces this image.
 >
-> - This image continues to be maintained. No deprecation date will be set until the new image is generally available.
+> - This image continues to be maintained. A deprecation date will be announced separately.
 >
-> New image: [Docker Hub](https://hub.docker.com/r/posit/workbench-session) | [GHCR](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session) | [GitHub](https://github.com/posit-dev/images-workbench) | [Discussions](https://github.com/posit-dev/images/discussions)
+> New image: <a href="https://hub.docker.com/r/posit/workbench-session">Docker Hub</a> | <a href="https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session">GHCR</a> | <a href="https://github.com/posit-dev/images-workbench">GitHub</a> | <a href="https://github.com/posit-dev/images/discussions">Discussions</a>
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
 * Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 

--- a/workbench-positron-init/README.md
+++ b/workbench-positron-init/README.md
@@ -1,5 +1,12 @@
 # Quick reference
 
+> [!NOTE]
+> A new <a href="https://github.com/posit-dev/images-workbench/blob/main/workbench-positron-init/README.md">posit/workbench-positron-init</a> image is now generally available and replaces this image.
+>
+> - This image continues to be maintained. A deprecation date will be announced separately.
+>
+> New image: <a href="https://hub.docker.com/r/posit/workbench-positron-init">Docker Hub</a> | <a href="https://github.com/posit-dev/images-workbench/pkgs/container/workbench-positron-init">GHCR</a> | <a href="https://github.com/posit-dev/images-workbench">GitHub</a> | <a href="https://github.com/posit-dev/images/discussions">Discussions</a>
+
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
 * Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues),
   [the Posit Workbench Documentation](https://docs.posit.co/ide/),

--- a/workbench-session-init/README.md
+++ b/workbench-session-init/README.md
@@ -1,11 +1,11 @@
 # Quick reference
 
 > [!NOTE]
-> A new [posit/workbench-session-init](https://github.com/posit-dev/images-workbench/blob/main/workbench-session-init/README.md) image is in preview and will eventually replace this image.
+> A new <a href="https://github.com/posit-dev/images-workbench/blob/main/workbench-session-init/README.md">posit/workbench-session-init</a> image is now generally available and replaces this image.
 >
-> - This image continues to be maintained. No deprecation date will be set until the new image is generally available.
+> - This image continues to be maintained. A deprecation date will be announced separately.
 >
-> New image: [Docker Hub](https://hub.docker.com/r/posit/workbench-session-init) | [GHCR](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session-init) | [GitHub](https://github.com/posit-dev/images-workbench) | [Discussions](https://github.com/posit-dev/images/discussions)
+> New image: <a href="https://hub.docker.com/r/posit/workbench-session-init">Docker Hub</a> | <a href="https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session-init">GHCR</a> | <a href="https://github.com/posit-dev/images-workbench">GitHub</a> | <a href="https://github.com/posit-dev/images/discussions">Discussions</a>
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
 * Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 

--- a/workbench-session/README.md
+++ b/workbench-session/README.md
@@ -1,11 +1,11 @@
 # Quick reference
 
 > [!NOTE]
-> A new [posit/workbench-session](https://github.com/posit-dev/images-workbench/blob/main/workbench-session/README.md) image is in preview and will eventually replace this image.
+> A new <a href="https://github.com/posit-dev/images-workbench/blob/main/workbench-session/README.md">posit/workbench-session</a> image is now generally available and replaces this image.
 >
-> - This image continues to be maintained. No deprecation date will be set until the new image is generally available.
+> - This image continues to be maintained. A deprecation date will be announced separately.
 >
-> New image: [Docker Hub](https://hub.docker.com/r/posit/workbench-session) | [GHCR](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session) | [GitHub](https://github.com/posit-dev/images-workbench) | [Discussions](https://github.com/posit-dev/images/discussions)
+> New image: <a href="https://hub.docker.com/r/posit/workbench-session">Docker Hub</a> | <a href="https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session">GHCR</a> | <a href="https://github.com/posit-dev/images-workbench">GitHub</a> | <a href="https://github.com/posit-dev/images/discussions">Discussions</a>
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
 * Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -1,11 +1,11 @@
 # Quick reference
 
 > [!NOTE]
-> A new [posit/workbench](https://github.com/posit-dev/images-workbench/blob/main/workbench/README.md) image is in preview and will eventually replace this image.
+> A new <a href="https://github.com/posit-dev/images-workbench/blob/main/workbench/README.md">posit/workbench</a> image is now generally available and replaces this image.
 >
-> - This image continues to be maintained. No deprecation date will be set until the new image is generally available.
+> - This image continues to be maintained. A deprecation date will be announced separately.
 >
-> New image: [Docker Hub](https://hub.docker.com/r/posit/workbench) | [GHCR](https://github.com/posit-dev/images-workbench/pkgs/container/workbench) | [GitHub](https://github.com/posit-dev/images-workbench) | [Discussions](https://github.com/posit-dev/images/discussions)
+> New image: <a href="https://hub.docker.com/r/posit/workbench">Docker Hub</a> | <a href="https://github.com/posit-dev/images-workbench/pkgs/container/workbench">GHCR</a> | <a href="https://github.com/posit-dev/images-workbench">GitHub</a> | <a href="https://github.com/posit-dev/images/discussions">Discussions</a>
 
 * Maintained by: [the Posit Docker team](https://github.com/rstudio/rstudio-docker-products)
 * Where to get help: [our Github Issues page](https://github.com/rstudio/rstudio-docker-products/issues), 


### PR DESCRIPTION
## Summary

- Update the cross-repo callout at the top of `README.md` to reflect that posit-dev/images is now generally available (was: "in preview").
- Replace the conditional "no deprecation date until GA" bullet with a forward-looking pointer that a deprecation date will be announced separately.

Refs posit-dev/images-shared#329.