### PR TITLE
Assert recursive file permissions on session image trees

### DIFF
--- a/workbench-positron-init/test/goss.yaml
+++ b/workbench-positron-init/test/goss.yaml
@@ -16,8 +16,8 @@ file:
 
 command:
   positron-files-other-read:
-    exec: 'find /opt/positron -type f -not -perm -004 -print | head -c1 | (! grep -q .)'
+    exec: 'find /opt/positron -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
     exit-status: 0
   positron-dirs-other-rx:
-    exec: 'find /opt/positron -type d -not -perm -005 -print | head -c1 | (! grep -q .)'
+    exec: 'find /opt/positron -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
     exit-status: 0

--- a/workbench-positron-init/test/goss.yaml
+++ b/workbench-positron-init/test/goss.yaml
@@ -13,3 +13,11 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+
+command:
+  positron-files-other-read:
+    exec: 'find /opt/positron -type f -not -perm -004 -print | head -c1 | (! grep -q .)'
+    exit-status: 0
+  positron-dirs-other-rx:
+    exec: 'find /opt/positron -type d -not -perm -005 -print | head -c1 | (! grep -q .)'
+    exit-status: 0

--- a/workbench-session-init/test/goss.yaml
+++ b/workbench-session-init/test/goss.yaml
@@ -95,3 +95,11 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+
+command:
+  session-components-files-other-read:
+    exec: 'find /opt/session-components -type f -not -perm -004 -print | head -c1 | (! grep -q .)'
+    exit-status: 0
+  session-components-dirs-other-rx:
+    exec: 'find /opt/session-components -type d -not -perm -005 -print | head -c1 | (! grep -q .)'
+    exit-status: 0

--- a/workbench-session-init/test/goss.yaml
+++ b/workbench-session-init/test/goss.yaml
@@ -98,8 +98,8 @@ file:
 
 command:
   session-components-files-other-read:
-    exec: 'find /opt/session-components -type f -not -perm -004 -print | head -c1 | (! grep -q .)'
+    exec: 'find /opt/session-components -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
     exit-status: 0
   session-components-dirs-other-rx:
-    exec: 'find /opt/session-components -type d -not -perm -005 -print | head -c1 | (! grep -q .)'
+    exec: 'find /opt/session-components -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
     exit-status: 0

--- a/workbench-session/test/goss.yaml
+++ b/workbench-session/test/goss.yaml
@@ -8,6 +8,9 @@ file:
     exists: true
   /etc/rstudio/positron.extensions.conf:
     exists: true
+  /opt:
+    exists: true
+    filetype: directory
 
 command:
   "echo '{ \"cells\": [], \"metadata\": {}, \"nbformat\": 4, \"nbformat_minor\": 2}' | /opt/python/jupyter/bin/jupyter nbconvert --to notebook --stdin --stdout":
@@ -47,10 +50,10 @@ command:
     title: pip_installed
     exit-status: 0
 
-  "find /usr/lib/rstudio-server -type f -not -perm -004 -print | head -c1 | (! grep -q .)":
-    title: rstudio-server-files-other-read
+  "find /opt -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)":
+    title: opt-files-other-read
     exit-status: 0
 
-  "find /usr/lib/rstudio-server -type d -not -perm -005 -print | head -c1 | (! grep -q .)":
-    title: rstudio-server-dirs-other-rx
+  "find /opt -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)":
+    title: opt-dirs-other-rx
     exit-status: 0

--- a/workbench-session/test/goss.yaml
+++ b/workbench-session/test/goss.yaml
@@ -46,3 +46,11 @@ command:
   "pip --version":
     title: pip_installed
     exit-status: 0
+
+  "find /usr/lib/rstudio-server -type f -not -perm -004 -print | head -c1 | (! grep -q .)":
+    title: rstudio-server-files-other-read
+    exit-status: 0
+
+  "find /usr/lib/rstudio-server -type d -not -perm -005 -print | head -c1 | (! grep -q .)":
+    title: rstudio-server-dirs-other-rx
+    exit-status: 0


### PR DESCRIPTION
## Summary

Adds two goss `command:` assertions per image that walk the staged tree the non-root k8s session must read, and fail if any file is missing the world-read bit or any directory is missing world-traverse/read bits. The existing tests only spot-check explicit files — a deeply nested binary or data file shipped without world-readable permissions would silently break non-root sessions today.

- `workbench-session-init/test/goss.yaml` — guards `/opt/session-components`
- `workbench-positron-init/test/goss.yaml` — guards `/opt/positron` (the path this image actually stages to; the issue used `/opt/session-components`)
- `workbench-session/test/goss.yaml` — guards `/opt` (covers R, Python, and rstudio-drivers — the trees the non-root session reads; the issue's `/usr/lib/rstudio-server` path is not staged in this image, the session binaries are mounted from `workbench-session-init` at runtime)

Pattern:

```
find <path> -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)
find <path> -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)
```

`2>&1` is intentional — without it, `find` complaining about a renamed/missing target writes to stderr, the pipeline leaves stdout empty, and the assertion silently passes. Merging stderr into stdout makes such a regression visible.

## Validation

Ran `run_tests.sh` against the currently-published `:ubuntu2204` tags:

- `rstudio/workbench-session-init:ubuntu2204` — 74/74 pass.
- `rstudio/workbench-positron-init:ubuntu2204` — 12/12 pass.
- `rstudio/workbench-session:ubuntu2204-r4.5.2_4.4.3-py3.13.9_3.12.11` — 18/18 pass.

Also confirmed the recursive assertion fires on a regression: `chmod 600` on a deeply nested file (one without an explicit `file:` rule) flips `*-files-other-read` to fail while the rest of the suite stays green. And confirmed the `2>&1` form fails on a missing target dir (the original form did not).

## Notes

The issue lists an optional defensive `chmod -R a+rX` in the Dockerfiles. Skipped here — the new assertions catch a regression either way.

Closes rstudio/rstudio-pro#10955