### PR TITLE
fix: stage nodejs/ runtime directory in connect-content-init

### DIFF
--- a/connect-content-init/NEWS.md
+++ b/connect-content-init/NEWS.md
@@ -1,3 +1,9 @@
+# 2026-06-01
+
+- Stage the `nodejs/` runtime directory in the init container so the Node.js
+  runtime is copied to the shared volume alongside `ext`, `python`, `R`, and
+  `scripts`.
+
 # 2025-11-05
 
 - Remove outdated default values for `ARG` instructions related to versions.

--- a/connect-content-init/entrypoint.sh
+++ b/connect-content-init/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 
 echo "Copying RStudio Connect runtime ..."
 
-for d in ext python R scripts ; do
+for d in ext python R scripts nodejs ; do
     echo copying $S/$d to $T/$d
     cp -va $S/$d $T/$d
 done


### PR DESCRIPTION
Backports posit-dev/images-connect#111. The init container's entrypoint copied `ext`, `python`, `R`, and `scripts` from the Connect runtime into the shared volume but omitted `nodejs`, leaving content that depends on the Node.js runtime without it.

connect-content-init/entrypoint.sh: add `nodejs` to the copy loop.