### PR TITLE
Add workbench-positron-init to migration table

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ The table below maps current images to their replacements.
 | `rstudio/r-session-complete` | [`docker.io/posit/workbench-session`](https://hub.docker.com/r/posit/workbench-session) | [`ghcr.io/posit-dev/workbench-session`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session) |
 | `rstudio/workbench-session` | [`docker.io/posit/workbench-session`](https://hub.docker.com/r/posit/workbench-session) | [`ghcr.io/posit-dev/workbench-session`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session) |
 | `rstudio/workbench-session-init` | [`docker.io/posit/workbench-session-init`](https://hub.docker.com/r/posit/workbench-session-init) | [`ghcr.io/posit-dev/workbench-session-init`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session-init) |
+| `rstudio/workbench-positron-init` | [`docker.io/posit/workbench-positron-init`](https://hub.docker.com/r/posit/workbench-positron-init) | [`ghcr.io/posit-dev/workbench-positron-init`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-positron-init) |
 
 # License
 


### PR DESCRIPTION
`workbench-positron-init` was added to the repo in April 2026, after the migration table was created in March 2026. Neither the initial addition nor the GA callout update (3e3dd39) added a row for it.

The two other images without table entries (`workbench-for-google-cloud-workstations` and `workbench-for-microsoft-azure-ml`) were on GAR/GHCR rather than Docker Hub and don't fit the table's `rstudio/` → `posit/` pattern, so they remain excluded.